### PR TITLE
DBZ-918 Adding Debezium connector field to source info

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/Module.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/Module.java
@@ -21,4 +21,8 @@ public final class Module {
     public static String version() {
         return INFO.getProperty("version");
     }
+
+    public static String name() {
+        return "oracle";
+    }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
@@ -7,11 +7,13 @@ package io.debezium.connector.oracle;
 
 import java.time.Instant;
 
+import io.debezium.annotation.NotThreadSafe;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.connector.AbstractSourceInfo;
 
+@NotThreadSafe
 public class SourceInfo extends AbstractSourceInfo {
 
     public static final String SERVER_NAME_KEY = "name";
@@ -43,6 +45,11 @@ public class SourceInfo extends AbstractSourceInfo {
     @Override
     protected Schema schema() {
         return SCHEMA;
+    }
+
+    @Override
+    protected String connector() {
+        return Module.name();
     }
 
     @Override

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SourceInfoTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SourceInfoTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class SourceInfoTest {
+
+    private SourceInfo source;
+
+    @Before
+    public void beforeEach() {
+        source = new SourceInfo("serverX");
+        source.setSourceTime(Instant.now());
+    }
+
+    @Test
+    public void versionIsPresent() {
+        assertThat(source.struct().getString(SourceInfo.DEBEZIUM_VERSION_KEY)).isEqualTo(Module.version());
+    }
+
+    @Test
+    public void connectorIsPresent() {
+        assertThat(source.struct().getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(Module.name());
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Module.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Module.java
@@ -21,4 +21,8 @@ public final class Module {
     public static String version() {
         return INFO.getProperty("version");
     }
+
+    public static String name() {
+        return "sqlserver";
+    }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceInfo.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceInfo.java
@@ -7,6 +7,7 @@ package io.debezium.connector.sqlserver;
 
 import java.time.Instant;
 
+import io.debezium.annotation.NotThreadSafe;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
@@ -19,6 +20,7 @@ import io.debezium.connector.AbstractSourceInfo;
  * @author Jiri Pechanec
  *
  */
+@NotThreadSafe
 public class SourceInfo extends AbstractSourceInfo {
 
     public static final String SERVER_NAME_KEY = "name";
@@ -91,6 +93,11 @@ public class SourceInfo extends AbstractSourceInfo {
     @Override
     protected Schema schema() {
         return SCHEMA;
+    }
+
+    @Override
+    protected String connector() {
+        return Module.name();
     }
 
     /**

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SourceInfoTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SourceInfoTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class SourceInfoTest {
+
+    private SourceInfo source;
+
+    @Before
+    public void beforeEach() {
+        source = new SourceInfo("serverX");
+        source.setChangeLsn(Lsn.NULL);
+    }
+
+    @Test
+    public void versionIsPresent() {
+        assertThat(source.struct().getString(SourceInfo.DEBEZIUM_VERSION_KEY)).isEqualTo(Module.version());
+    }
+
+    @Test
+    public void connectorIsPresent() {
+        assertThat(source.struct().getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(Module.name());
+    }
+}


### PR DESCRIPTION
This will allow consumers to recognize the Debezium connector used for creating a given message, helping them to adjust their behavior for a variety of connectors.

https://issues.jboss.org/browse/DBZ-918