### PR TITLE
DBZ-941 Add "snapshot" snapshot locking mode

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -117,6 +117,12 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         EXCLUSIVE("exclusive"),
 
         /**
+         * This mode uses SNAPSHOT isolation level.  This way reads and writes are not blocked for the entire duration
+         * of the snapshot.  Snapshot consistency is guaranteed as long as DDL statements are not executed at the time.
+         */
+        SNAPSHOT("snapshot"),
+
+        /**
          * This mode will avoid using ANY table locks during the snapshot process.  This mode can only be used with SnapShotMode
          * set to schema_only or schema_only_recovery.
          */

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.sqlserver;
 
+import static io.debezium.connector.sqlserver.SqlServerConnectorConfig.SNAPSHOT_LOCKING_MODE;
 import static org.junit.Assert.assertNull;
 
 import java.math.BigDecimal;
@@ -13,6 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotLockingMode;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -73,8 +75,24 @@ public class SnapshotIT extends AbstractConnectorTest {
     }
 
     @Test
-    public void takeSnapshot() throws Exception {
-        final Configuration config = TestHelper.defaultConfig().build();
+    public void takeSnapshotInExclusiveMode() throws Exception {
+        takeSnapshot(SnapshotLockingMode.EXCLUSIVE);
+    }
+
+    @Test
+    public void takeSnapshotInSnapshotMode() throws Exception {
+        takeSnapshot(SnapshotLockingMode.SNAPSHOT);
+    }
+
+    @Test
+    public void takeSnapshotInNoneMode() throws Exception {
+        takeSnapshot(SnapshotLockingMode.NONE);
+    }
+
+    private void takeSnapshot(SnapshotLockingMode lockingMode) throws Exception {
+        final Configuration config = TestHelper.defaultConfig()
+            .with(SNAPSHOT_LOCKING_MODE.name(), lockingMode.getValue())
+            .build();
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -77,11 +77,12 @@ public class TestHelper {
                     + "CREATE DATABASE testDB\n";
             connection.execute(sql);
             connection.execute("USE testDB");
+            connection.execute("ALTER DATABASE testDB SET ALLOW_SNAPSHOT_ISOLATION ON");
             // NOTE: you cannot enable CDC on master
             connection.enableDbCdc("testDB");
         }
         catch (SQLException e) {
-            throw new IllegalStateException("Error while initating test database", e);
+            throw new IllegalStateException("Error while initiating test database", e);
         }
     }
 


### PR DESCRIPTION
The entire initial snapshot process is executed in snapshot transaction
isolation level.