### PR TITLE
DBZ-947 SQL Server snapshot.locking.modes overhaul

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -126,14 +126,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
          * This mode uses REPEATABLE READ isolation level.  This mode will avoid taking any table locks
          * during the snapshot process.  Since phantom reads can occur, it does not fully guarantee consistency.
          */
-        REPEATABLE_READ("repeatable_read"),
-
-        /**
-         * The snapshot uses READ COMMITTED isolation level.  Neither table locks nor row-level locks are taken.
-         * This way other transactions are not affected by initial snapshot process.  However, snapshot consistency is
-         * not guaranteed.
-         */
-        READ_COMMITTED("read_committed");
+        REPEATABLE_READ("repeatable_read");
 
         private final String value;
 
@@ -212,10 +205,9 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
             .withDescription("Controls which transaction isolation level is used and how long the connector locks the monitored tables for snapshot execution. "
-                + "The default is '" + SnapshotIsolationMode.REPEATABLE_READ.getValue() + "', which means that the connector does not hold any locks for all monitored tables. "
+                + "The default is '" + SnapshotIsolationMode.REPEATABLE_READ.getValue() + "', which means that the connector does not hold any table locks for all monitored tables. "
                 + "Using a value of '" + SnapshotIsolationMode.EXCLUSIVE.getValue() + "' ensures that the connector holds the exclusive lock (and thus prevents any reads and updates) for all monitored tables. "
-                + "When '" + SnapshotIsolationMode.SNAPSHOT.getValue() + "' is specified, connector runs the initial snapshot in SNAPSHOT isolation level, which guarantees snapshot consistency. In addition, neither table nor row-level locks are held. "
-                + "In '" + SnapshotIsolationMode.READ_COMMITTED.getValue() + "' mode neither table nor row-level locks are acquired, but connector does not guarantee snapshot consistency.");
+                + "When '" + SnapshotIsolationMode.SNAPSHOT.getValue() + "' is specified, connector runs the initial snapshot in SNAPSHOT isolation level, which guarantees snapshot consistency. In addition, neither table nor row-level locks are held.");
 
     /**
      * The set of {@link Field}s defined as part of this configuration.

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -126,7 +126,14 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
          * This mode uses REPEATABLE READ isolation level.  This mode will avoid taking any table locks
          * during the snapshot process.  Since phantom reads can occur, it does not fully guarantee consistency.
          */
-        REPEATABLE_READ("repeatable_read");
+        REPEATABLE_READ("repeatable_read"),
+
+        /**
+         * This mode uses READ UNCOMMITTED isolation level.  This mode takes neither table locks nor row-level locks
+         * during the snapshot process.  This way other transactions are not affected by initial snapshot process.
+         * However, snapshot consistency is not guaranteed.
+         */
+        READ_UNCOMMITTED("read_uncommitted");
 
         private final String value;
 
@@ -207,7 +214,8 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             .withDescription("Controls which transaction isolation level is used and how long the connector locks the monitored tables for snapshot execution. "
                 + "The default is '" + SnapshotIsolationMode.REPEATABLE_READ.getValue() + "', which means that the connector does not hold any table locks for all monitored tables. "
                 + "Using a value of '" + SnapshotIsolationMode.EXCLUSIVE.getValue() + "' ensures that the connector holds the exclusive lock (and thus prevents any reads and updates) for all monitored tables. "
-                + "When '" + SnapshotIsolationMode.SNAPSHOT.getValue() + "' is specified, connector runs the initial snapshot in SNAPSHOT isolation level, which guarantees snapshot consistency. In addition, neither table nor row-level locks are held.");
+                + "When '" + SnapshotIsolationMode.SNAPSHOT.getValue() + "' is specified, connector runs the initial snapshot in SNAPSHOT isolation level, which guarantees snapshot consistency. In addition, neither table nor row-level locks are held. "
+                + "In '" + SnapshotIsolationMode.READ_UNCOMMITTED.getValue() + "' mode neither table nor row-level locks are acquired, but connector does not guarantee snapshot consistency.");
 
     /**
      * The set of {@link Field}s defined as part of this configuration.

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -95,7 +95,11 @@ public class SqlServerSnapshotChangeEventSource extends HistorizedRelationalSnap
 
     @Override
     protected void lockTablesForSchemaSnapshot(ChangeEventSourceContext sourceContext, SnapshotContext snapshotContext) throws SQLException, InterruptedException {
-        if (connectorConfig.getSnapshotIsolationMode() == SnapshotIsolationMode.REPEATABLE_READ) {
+        if (connectorConfig.getSnapshotIsolationMode() == SnapshotIsolationMode.READ_UNCOMMITTED) {
+            jdbcConnection.connection().setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
+            LOGGER.info("Schema locking was disabled in connector configuration");
+        }
+        else if (connectorConfig.getSnapshotIsolationMode() == SnapshotIsolationMode.REPEATABLE_READ) {
             jdbcConnection.connection().setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
             LOGGER.info("Schema locking was disabled in connector configuration");
         }
@@ -127,7 +131,7 @@ public class SqlServerSnapshotChangeEventSource extends HistorizedRelationalSnap
     @Override
     protected void releaseSchemaSnapshotLocks(SnapshotContext snapshotContext) throws SQLException {
         // Exclusive mode: locks should be kept until the end of transaction.
-        // repeatable read mode; snapshot mode: no locks have been acquired.
+        // read uncommitted; repeatable read mode; snapshot mode: no locks have been acquired.
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -95,12 +95,7 @@ public class SqlServerSnapshotChangeEventSource extends HistorizedRelationalSnap
 
     @Override
     protected void lockTablesForSchemaSnapshot(ChangeEventSourceContext sourceContext, SnapshotContext snapshotContext) throws SQLException, InterruptedException {
-        if (connectorConfig.getSnapshotIsolationMode() == SnapshotIsolationMode.READ_COMMITTED) {
-            // No table locks acquired. Read committed isolation level is used to avoid taking shared locks on rows.
-            jdbcConnection.connection().setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
-            LOGGER.info("Schema locking was disabled in connector configuration");
-        }
-        else if (connectorConfig.getSnapshotIsolationMode() == SnapshotIsolationMode.REPEATABLE_READ) {
+        if (connectorConfig.getSnapshotIsolationMode() == SnapshotIsolationMode.REPEATABLE_READ) {
             jdbcConnection.connection().setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
             LOGGER.info("Schema locking was disabled in connector configuration");
         }
@@ -132,7 +127,7 @@ public class SqlServerSnapshotChangeEventSource extends HistorizedRelationalSnap
     @Override
     protected void releaseSchemaSnapshotLocks(SnapshotContext snapshotContext) throws SQLException {
         // Exclusive mode: locks should be kept until the end of transaction.
-        // read committed; repeatable read mode; snapshot mode: no locks have been acquired.
+        // repeatable read mode; snapshot mode: no locks have been acquired.
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
@@ -5,7 +5,7 @@
  */
 package io.debezium.connector.sqlserver;
 
-import static io.debezium.connector.sqlserver.SqlServerConnectorConfig.SNAPSHOT_LOCKING_MODE;
+import static io.debezium.connector.sqlserver.SqlServerConnectorConfig.SNAPSHOT_ISOLATION_MODE;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
 
@@ -14,6 +14,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 
+import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotIsolationMode;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -26,7 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.debezium.config.Configuration;
-import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotLockingMode;
 import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotMode;
 import io.debezium.connector.sqlserver.util.TestHelper;
 import io.debezium.data.SchemaAndValueField;
@@ -79,22 +79,27 @@ public class SnapshotIT extends AbstractConnectorTest {
 
     @Test
     public void takeSnapshotInExclusiveMode() throws Exception {
-        takeSnapshot(SnapshotLockingMode.EXCLUSIVE);
+        takeSnapshot(SnapshotIsolationMode.EXCLUSIVE);
     }
 
     @Test
     public void takeSnapshotInSnapshotMode() throws Exception {
-        takeSnapshot(SnapshotLockingMode.SNAPSHOT);
+        takeSnapshot(SnapshotIsolationMode.SNAPSHOT);
     }
 
     @Test
-    public void takeSnapshotInNoneMode() throws Exception {
-        takeSnapshot(SnapshotLockingMode.NONE);
+    public void takeSnapshotInRepeatableReadMode() throws Exception {
+        takeSnapshot(SnapshotIsolationMode.REPEATABLE_READ);
     }
 
-    private void takeSnapshot(SnapshotLockingMode lockingMode) throws Exception {
+    @Test
+    public void takeSnapshotInReadCommittedMode() throws Exception {
+        takeSnapshot(SnapshotIsolationMode.READ_COMMITTED);
+    }
+
+    private void takeSnapshot(SnapshotIsolationMode lockingMode) throws Exception {
         final Configuration config = TestHelper.defaultConfig()
-            .with(SNAPSHOT_LOCKING_MODE.name(), lockingMode.getValue())
+            .with(SNAPSHOT_ISOLATION_MODE.name(), lockingMode.getValue())
             .build();
 
         start(SqlServerConnector.class, config);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
@@ -92,11 +92,6 @@ public class SnapshotIT extends AbstractConnectorTest {
         takeSnapshot(SnapshotIsolationMode.REPEATABLE_READ);
     }
 
-    @Test
-    public void takeSnapshotInReadCommittedMode() throws Exception {
-        takeSnapshot(SnapshotIsolationMode.READ_COMMITTED);
-    }
-
     private void takeSnapshot(SnapshotIsolationMode lockingMode) throws Exception {
         final Configuration config = TestHelper.defaultConfig()
             .with(SNAPSHOT_ISOLATION_MODE.name(), lockingMode.getValue())

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
@@ -92,6 +92,11 @@ public class SnapshotIT extends AbstractConnectorTest {
         takeSnapshot(SnapshotIsolationMode.REPEATABLE_READ);
     }
 
+    @Test
+    public void takeSnapshotInReadUncommittedMode() throws Exception {
+        takeSnapshot(SnapshotIsolationMode.READ_UNCOMMITTED);
+    }
+
     private void takeSnapshot(SnapshotIsolationMode lockingMode) throws Exception {
         final Configuration config = TestHelper.defaultConfig()
             .with(SNAPSHOT_ISOLATION_MODE.name(), lockingMode.getValue())


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-947

Exclusive mode: In order to provide a consistent snapshot, exclusive locks
are taken on all monitored tables during entire snapshot process duration.
    
Snapshot mode: The initial snapshot is executed in snapshot transaction
isolation level. This guarantees consistent snapshot as long as DDL
statements are not executed. In addition, neither table locks nor
row-level locks are acquired.
    
Repeatable read mode: The initial snapshot is executed in repeatable read
transaction level. Since phantom reads can occur, it does not fully
guarantee consistency.
    
None mode: Neither table locks nor row-level locks are taken. This way
other transactions are not affected by initial snapshot process.
However, snapshot consistency is not guaranteed. In addition, DDL
statements must not be executed during the snapshot.
