### PR TITLE
DBZ-776 Removing redundant method;

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
@@ -5,15 +5,9 @@
  */
 package io.debezium.connector.sqlserver;
 
-import java.sql.SQLException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.debezium.annotation.ThreadSafe;
 import io.debezium.relational.HistorizedRelationalDatabaseSchema;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -29,14 +23,10 @@ import io.debezium.util.SchemaNameAdjuster;
  * Logical representation of SQL Server schema.
  *
  * @author Jiri Pechanec
- *
  */
 public class SqlServerDatabaseSchema extends HistorizedRelationalDatabaseSchema {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerDatabaseSchema.class);
-
-    @ThreadSafe
-    private final Set<TableId> capturedTables;
 
     public SqlServerDatabaseSchema(SqlServerConnectorConfig connectorConfig, SchemaNameAdjuster schemaNameAdjuster, TopicSelector<TableId> topicSelector, SqlServerConnection connection) {
         super(connectorConfig, topicSelector, connectorConfig.getTableFilters().dataCollectionFilter(), null,
@@ -46,12 +36,6 @@ public class SqlServerDatabaseSchema extends HistorizedRelationalDatabaseSchema 
                         SourceInfo.SCHEMA
                 ),
                 false);
-        try {
-            this.capturedTables = Collections.unmodifiableSet(determineCapturedTables(connectorConfig, connection));
-        }
-        catch (SQLException e) {
-            throw new IllegalStateException("Could not obtain the list of captured tables", e);
-        }
     }
 
     @Override
@@ -70,27 +54,6 @@ public class SqlServerDatabaseSchema extends HistorizedRelationalDatabaseSchema 
         }
 
         record(schemaChange, tableChanges);
-    }
-
-    public Set<TableId> getCapturedTables() {
-        return capturedTables;
-    }
-
-    private static Set<TableId> determineCapturedTables(SqlServerConnectorConfig connectorConfig, SqlServerConnection connection) throws SQLException {
-        final Set<TableId> allTableIds = connection.readTableNames(connectorConfig.getDatabaseName(), null, null, new String[] {"TABLE"} );
-
-        final Set<TableId> capturedTables = new HashSet<>();
-
-        for (TableId tableId : allTableIds) {
-            if (connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)) {
-                capturedTables.add(tableId);
-            }
-            else {
-                LOGGER.trace("Skipping table {} as it's not included in the filter configuration", tableId);
-            }
-        }
-
-        return capturedTables;
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -58,7 +58,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
     public void execute(ChangeEventSourceContext context) throws InterruptedException {
         final Metronome metronome = Metronome.sleeper(pollInterval, clock);
         try {
-            final TableId[] tables = schema.getCapturedTables().toArray(new TableId[schema.getCapturedTables().size()]);
+            final TableId[] tables = schema.tableIds().toArray(new TableId[0]);
             final Lsn lastProcessedLsnOnStart = offsetContext.getChangeLsn();
             LOGGER.info("Last LSN recorded in offsets is {}", lastProcessedLsnOnStart);
             Lsn lastProcessedLsn = offsetContext.getChangeLsn();


### PR DESCRIPTION
Adjusting test for database property pass-through, as the connection isn't established any longer synchronously within start().