### PR TITLE
DBZ-954 Oracle Connector doesn't support Oracle 11g (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode/**
+
 activemq-data/
 .idea/
 *.iml

--- a/README.md
+++ b/README.md
@@ -34,22 +34,43 @@ In order to build the Debezium Oracle connector, the following prerequisites mus
 (Running Oracle in VirtualBox is not a requirement, but we found it to be the easiest in terms of set-up)
 * The Instant Client is downloaded (e.g. [from here](http://www.oracle.com/technetwork/topics/linuxx86-64soft-092277.html) for Linux) and unpacked
 * The _xstream.jar_ and _ojdbc8.jar_ from the Instant Client directory must be installed to the local Maven repository:
-  * mvn install:install-file \
+
+```bash
+mvn install:install-file \
   -DgroupId=com.oracle.instantclient \
   -DartifactId=ojdbc8 \
   -Dversion=12.1.0.2 \
   -Dpackaging=jar \
-  -Dfile=ojdbc8.jar`
-  * mvn install:install-file \
+  -Dfile=ojdbc8.jar
+
+mvn install:install-file \
   -DgroupId=com.oracle.instantclient \
   -DartifactId=xstreams \
   -Dversion=12.1.0.2 \
   -Dpackaging=jar \
   -Dfile=xstreams.jar
+```
 
 Then the Oracle connector can be built like so:
 
     $ mvn clean install -pl debezium-connector-oracle -am -Poracle -Dinstantclient.dir=/path/to/instant-client-dir
+
+## For Oracle 11g
+
+To run Debezium oracle connector with Oracle 11g, add these additional parameters. If run with Oralce 12c+, leave these parameters to default.
+
+```json
+"database.tablename.case.insensitive": "true"
+"database.oracle.version": "11"
+```
+
+By default, DBZ will ignore some admin tables in oracle 12c, but those tables are different in oracle 11g, by now, DBZ will report error on those tables. So when use DBZ on oracle 11g, use table white list, remember to use lower case.
+
+Example:
+
+```json
+"table.whitelist":"orcl\\.debezium\\.(.*)"
+```
 
 ## Contributing
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/LcrEventHandler.java
@@ -37,13 +37,15 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     private final Clock clock;
     private final RelationalDatabaseSchema schema;
     private final OracleOffsetContext offsetContext;
+    private final boolean tablenameCaseInsensitive;
 
-    public LcrEventHandler(ErrorHandler errorHandler, EventDispatcher<TableId> dispatcher, Clock clock, RelationalDatabaseSchema schema, OracleOffsetContext offsetContext) {
+    public LcrEventHandler(ErrorHandler errorHandler, EventDispatcher<TableId> dispatcher, Clock clock, RelationalDatabaseSchema schema, OracleOffsetContext offsetContext,boolean tablenameCaseInsensitive) {
         this.errorHandler = errorHandler;
         this.dispatcher = dispatcher;
         this.clock = clock;
         this.schema = schema;
         this.offsetContext = offsetContext;
+        this.tablenameCaseInsensitive = tablenameCaseInsensitive;
     }
 
     @Override
@@ -117,7 +119,13 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     }
 
     private TableId getTableId(LCR lcr) {
-        return new TableId(lcr.getSourceDatabaseName(), lcr.getObjectOwner(), lcr.getObjectName());
+        if (!this.tablenameCaseInsensitive) {
+            return new TableId(lcr.getSourceDatabaseName(), lcr.getObjectOwner(), lcr.getObjectName());
+        }
+        else {
+            return new TableId(lcr.getSourceDatabaseName().toLowerCase(), lcr.getObjectOwner(), lcr.getObjectName().toLowerCase());
+        }
+        
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -23,6 +23,7 @@ import io.debezium.relational.TableId;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.history.HistoryRecordComparator;
 import io.debezium.relational.history.KafkaDatabaseHistory;
+import oracle.streams.XStreamUtility;
 
 /**
  * Connector configuration for Oracle.
@@ -80,6 +81,19 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     + "'initial' (the default) to specify the connector should run a snapshot only when no offsets are available for the logical server name; "
                     + "'initial_schema_only' to specify the connector should run a snapshot of the schema when no offsets are available for the logical server name. ");
 
+    public static final Field TABLENAME_CASE_INSENSITIVE = Field.create("database.tablename.case.insensitive")
+        .withDisplayName("Case insensitive table names")
+        .withType(Type.BOOLEAN)
+        .withDefault(false)
+        .withImportance(Importance.LOW)
+        .withDescription("Case insensitive table names; set to 'true' for Oracle 11g, 'false' (default) otherwise.");
+    
+    public static final Field ORACLE_VERSION = Field.create("database.oracle.version")
+        .withDisplayName("Oracle version, 11 or 12+")
+        .withEnum(OracleVersion.class, OracleVersion.V12Plus)
+        .withImportance(Importance.LOW)
+        .withDescription("For default oracle 12+, use default pos_version value v2, for oracle 11, use pos_version value v1.");
+
     /**
      * The set of {@link Field}s defined as part of this configuration.
      */
@@ -97,13 +111,18 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             CommonConnectorConfig.MAX_BATCH_SIZE,
             CommonConnectorConfig.MAX_QUEUE_SIZE,
             Heartbeat.HEARTBEAT_INTERVAL,
-            Heartbeat.HEARTBEAT_TOPICS_PREFIX
+            Heartbeat.HEARTBEAT_TOPICS_PREFIX,
+            TABLENAME_CASE_INSENSITIVE,
+            ORACLE_VERSION
     );
 
     private final String databaseName;
     private final String pdbName;
     private final String xoutServerName;
     private final SnapshotMode snapshotMode;
+
+    private final boolean tablenameCaseInsensitive;
+    private final OracleVersion oracleVersion;
 
     public OracleConnectorConfig(Configuration config) {
         super(config, config.getString(LOGICAL_NAME), new SystemTablesPredicate());
@@ -112,6 +131,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.pdbName = config.getString(PDB_NAME);
         this.xoutServerName = config.getString(XSTREAM_SERVER_NAME);
         this.snapshotMode = SnapshotMode.parse(config.getString(SNAPSHOT_MODE));
+        this.tablenameCaseInsensitive = config.getBoolean(TABLENAME_CASE_INSENSITIVE);
+        this.oracleVersion = OracleVersion.parse(config.getString(ORACLE_VERSION));
     }
 
     public static ConfigDef configDef() {
@@ -147,6 +168,14 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         return snapshotMode;
     }
 
+    public boolean  getTablenameCaseInsensitive() {
+        return tablenameCaseInsensitive;
+    }
+
+    public OracleVersion getOracleVersion() {
+        return oracleVersion;
+    }
+
     @Override
     protected HistoryRecordComparator getHistoryRecordComparator() {
         return new HistoryRecordComparator() {
@@ -155,6 +184,56 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                 return (recorded.getLong(SourceInfo.SCN_KEY).compareTo(desired.getLong(SourceInfo.SCN_KEY)) < 1);
             }
         };
+    }
+
+    public static enum OracleVersion implements EnumeratedValue {
+
+        V11("11"),
+        V12Plus("12+");
+        private final String version;
+
+        private OracleVersion(String version) {
+            this.version = version;
+        }
+
+        @Override
+        public String getValue() {
+            return version;
+        }
+
+        public int getPosVersion() {
+            switch(version) {
+                case "11": 
+                    return XStreamUtility.POS_VERSION_V1;
+                case "12+": 
+                    return XStreamUtility.POS_VERSION_V2;
+                default: 
+                    return XStreamUtility.POS_VERSION_V2;
+            }
+        }
+
+        public static OracleVersion parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+
+            for (OracleVersion option : OracleVersion.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) return option;
+            }
+
+            return null;
+        }
+
+        public static OracleVersion parse(String value, String defaultValue) {
+            OracleVersion option = parse(value);
+
+            if (option == null && defaultValue != null) {
+                option = parse(defaultValue);
+            }
+
+            return option;
+        }
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
@@ -30,8 +30,8 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
 
     public OracleDatabaseSchema(OracleConnectorConfig connectorConfig, SchemaNameAdjuster schemaNameAdjuster, TopicSelector<TableId> topicSelector, OracleConnection connection) {
         super(connectorConfig, topicSelector, connectorConfig.getTableFilters().dataCollectionFilter(), null,
-                new TableSchemaBuilder(new OracleValueConverters(connection), schemaNameAdjuster, SourceInfo.SCHEMA),
-                false);
+            new TableSchemaBuilder(new OracleValueConverters(connection), schemaNameAdjuster, SourceInfo.SCHEMA),
+            connectorConfig.getTablenameCaseInsensitive());  
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleStreamingChangeEventSource.java
@@ -40,6 +40,8 @@ public class OracleStreamingChangeEventSource implements StreamingChangeEventSou
     private final OracleOffsetContext offsetContext;
     private final String xStreamServerName;
     private volatile XStreamOut xsOut;
+    private final boolean tablenameCaseInsensitive;
+    private final int posVersion;
 
     public OracleStreamingChangeEventSource(OracleConnectorConfig connectorConfig, OracleOffsetContext offsetContext, JdbcConnection jdbcConnection, EventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock, OracleDatabaseSchema schema) {
         this.jdbcConnection = jdbcConnection;
@@ -49,6 +51,8 @@ public class OracleStreamingChangeEventSource implements StreamingChangeEventSou
         this.schema = schema;
         this.offsetContext = offsetContext;
         this.xStreamServerName = connectorConfig.getXoutServerName();
+        this.tablenameCaseInsensitive = connectorConfig.getTablenameCaseInsensitive();
+        this.posVersion = connectorConfig.getOracleVersion().getPosVersion();
     }
 
     @Override
@@ -58,7 +62,7 @@ public class OracleStreamingChangeEventSource implements StreamingChangeEventSou
             xsOut = XStreamOut.attach((OracleConnection) jdbcConnection.connection(), xStreamServerName,
                     convertScnToPosition(offsetContext.getScn()), 1, 1, XStreamOut.DEFAULT_MODE);
 
-            LcrEventHandler handler = new LcrEventHandler(errorHandler, dispatcher, clock, schema, offsetContext);
+            LcrEventHandler handler = new LcrEventHandler(errorHandler, dispatcher, clock, schema, offsetContext, this.tablenameCaseInsensitive);
 
             // 2. receive events while running
             while(context.isRunning()) {
@@ -104,7 +108,7 @@ public class OracleStreamingChangeEventSource implements StreamingChangeEventSou
 
     private byte[] convertScnToPosition(long scn) {
         try {
-            return XStreamUtility.convertSCNToPosition(new NUMBER(scn), XStreamUtility.POS_VERSION_V2);
+            return XStreamUtility.convertSCNToPosition(new NUMBER(scn), this.posVersion);
         }
         catch (StreamsException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
The original dbz can't run with oracle 11g, so add 2 parameters:
database.tablename.case.insensitive, default is false, set to true for oracle 11g.
database.position.version, default is v2, set to v1 for oracle 11g.