### PR TITLE
[DBZ-1406] Replace Yaml Dependency With Property file.

### DIFF
--- a/debezium-connector-cassandra/pom.xml
+++ b/debezium-connector-cassandra/pom.xml
@@ -52,11 +52,6 @@
             <version>${version.dropwizard}</version>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.20</version>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
             <version>9.4.12.v20180830</version>

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -340,8 +340,7 @@ public class CassandraConnectorConfig {
 
     public CommitLogTransfer getCommitLogTransfer() {
         try {
-            String clazz = configs.containsKey(COMMIT_LOG_TRANSFER_CLASS) ?
-                    (String) configs.get(COMMIT_LOG_TRANSFER_CLASS) : DEFAULT_COMMIT_LOG_TRANSFER_CLASS;
+            String clazz = (String) configs.getOrDefault(COMMIT_LOG_TRANSFER_CLASS, DEFAULT_COMMIT_LOG_TRANSFER_CLASS);
             CommitLogTransfer transfer = (CommitLogTransfer) Class.forName(clazz).newInstance();
             transfer.init(commitLogTransferConfigs());
             return transfer;

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -278,7 +278,8 @@ public class CassandraConnectorConfig {
     }
 
     public boolean latestCommitLogOnly() {
-        return (boolean) configs.getOrDefault(LATEST_COMMIT_LOG_ONLY, DEFAULT_LATEST_COMMIT_LOG_ONLY);
+        return configs.containsKey(LATEST_COMMIT_LOG_ONLY) ?
+                Boolean.parseBoolean((String) configs.get(LATEST_COMMIT_LOG_ONLY)) : DEFAULT_LATEST_COMMIT_LOG_ONLY;
     }
 
     public SnapshotMode snapshotMode() {
@@ -293,7 +294,7 @@ public class CassandraConnectorConfig {
     }
 
     public int httpPort() {
-        return (int) configs.getOrDefault(HTTP_PORT, DEFAULT_HTTP_PORT);
+        return configs.containsKey(HTTP_PORT) ? Integer.parseInt((String) configs.get(HTTP_PORT)) : DEFAULT_HTTP_PORT;
     }
 
     public String cassandraConfig() {
@@ -306,11 +307,13 @@ public class CassandraConnectorConfig {
     }
 
     public int cassandraPort() {
-        return (int) configs.getOrDefault(CASSANDRA_PORT, DEFAULT_CASSANDRA_PORT);
+        return configs.containsKey(CASSANDRA_PORT) ?
+                Integer.parseInt((String) configs.get(CASSANDRA_PORT)) : DEFAULT_CASSANDRA_PORT;
     }
 
     public boolean cassandraSslEnabled() {
-        return (boolean) configs.getOrDefault(CASSANDRA_SSL_ENABLED, DEFAULT_CASSANDRA_SSL_ENABLED);
+        return configs.containsKey(CASSANDRA_SSL_ENABLED) ?
+                Boolean.parseBoolean((String) configs.get(CASSANDRA_SSL_ENABLED)) : DEFAULT_CASSANDRA_SSL_ENABLED;
     }
 
     public String cassandraSslConfigPath() {
@@ -330,12 +333,15 @@ public class CassandraConnectorConfig {
     }
 
     public boolean postProcessEnabled() {
-        return (boolean) configs.getOrDefault(COMMIT_LOG_POST_PROCESSING_ENABLED, DEFAULT_COMMIT_LOG_POST_PROCESSING_ENABLED);
+        return configs.containsKey(COMMIT_LOG_POST_PROCESSING_ENABLED) ?
+                Boolean.parseBoolean((String) configs.get(COMMIT_LOG_POST_PROCESSING_ENABLED)) :
+                DEFAULT_COMMIT_LOG_POST_PROCESSING_ENABLED;
     }
 
     public CommitLogTransfer getCommitLogTransfer() {
         try {
-            String clazz = (String) configs.getOrDefault(COMMIT_LOG_TRANSFER_CLASS, DEFAULT_COMMIT_LOG_TRANSFER_CLASS);
+            String clazz = configs.containsKey(COMMIT_LOG_TRANSFER_CLASS) ?
+                    (String) configs.get(COMMIT_LOG_TRANSFER_CLASS) : DEFAULT_COMMIT_LOG_TRANSFER_CLASS;
             CommitLogTransfer transfer = (CommitLogTransfer) Class.forName(clazz).newInstance();
             transfer.init(commitLogTransferConfigs());
             return transfer;
@@ -349,39 +355,47 @@ public class CassandraConnectorConfig {
     }
 
     public Duration offsetFlushIntervalMs() {
-        int ms = (int) configs.getOrDefault(OFFSET_FLUSH_INTERVAL_MS, DEFAULT_OFFSET_FLUSH_INTERVAL_MS);
+        int ms = configs.containsKey(OFFSET_FLUSH_INTERVAL_MS) ?
+                Integer.parseInt((String) configs.get(OFFSET_FLUSH_INTERVAL_MS)) : DEFAULT_OFFSET_FLUSH_INTERVAL_MS;
         return Duration.ofMillis(ms);
     }
 
     public long maxOffsetFlushSize() {
-        return (int) configs.getOrDefault(MAX_OFFSET_FLUSH_SIZE, DEFAULT_MAX_OFFSET_FLUSH_SIZE);
+        return configs.containsKey(MAX_OFFSET_FLUSH_SIZE) ?
+                Long.parseLong((String) configs.get(MAX_OFFSET_FLUSH_SIZE)) : DEFAULT_MAX_OFFSET_FLUSH_SIZE;
     }
 
     public int maxQueueSize() {
-        return (int) configs.getOrDefault(MAX_QUEUE_SIZE, DEFAULT_MAX_QUEUE_SIZE);
+        return configs.containsKey(MAX_QUEUE_SIZE) ?
+                Integer.parseInt((String) configs.get(MAX_QUEUE_SIZE)) : DEFAULT_MAX_QUEUE_SIZE;
     }
 
     public int maxBatchSize() {
-        return (int) configs.getOrDefault(MAX_BATCH_SIZE, DEFAULT_MAX_BATCH_SIZE);
+        return configs.containsKey(MAX_BATCH_SIZE) ?
+                Integer.parseInt((String) configs.get(MAX_BATCH_SIZE)) : DEFAULT_MAX_BATCH_SIZE;
     }
 
     public Duration pollIntervalMs() {
-        int ms = (int) configs.getOrDefault(POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS);
+        int ms = configs.containsKey(POLL_INTERVAL_MS) ?
+                Integer.parseInt((String) configs.get(POLL_INTERVAL_MS)) : DEFAULT_POLL_INTERVAL_MS;
         return Duration.ofMillis(ms);
     }
 
     public Duration schemaPollIntervalMs() {
-        int ms = (int) configs.getOrDefault(SCHEMA_POLL_INTERVAL_MS, DEFAULT_SCHEMA_POLL_INTERVAL_MS);
+        int ms = configs.containsKey(SCHEMA_POLL_INTERVAL_MS) ?
+                Integer.parseInt((String) configs.get(SCHEMA_POLL_INTERVAL_MS)) : DEFAULT_SCHEMA_POLL_INTERVAL_MS;
         return Duration.ofMillis(ms);
     }
 
     public Duration cdcDirPollIntervalMs() {
-        int ms = (int) configs.getOrDefault(CDC_DIR_POLL_INTERVAL_MS, DEFAULT_CDC_DIR_POLL_INTERVAL_MS);
+        int ms = configs.containsKey(CDC_DIR_POLL_INTERVAL_MS) ?
+                Integer.parseInt((String) configs.get(CDC_DIR_POLL_INTERVAL_MS)) : DEFAULT_CDC_DIR_POLL_INTERVAL_MS;
         return Duration.ofMillis(ms);
     }
 
     public Duration snapshotPollIntervalMs() {
-        int ms = (int) configs.getOrDefault(SNAPSHOT_POLL_INTERVAL_MS, DEFAULT_SNAPSHOT_POLL_INTERVAL_MS);
+        int ms = configs.containsKey(SNAPSHOT_POLL_INTERVAL_MS) ?
+                Integer.parseInt((String) configs.get(SNAPSHOT_POLL_INTERVAL_MS)) : DEFAULT_SNAPSHOT_POLL_INTERVAL_MS;
         return Duration.ofMillis(ms);
     }
 
@@ -394,7 +408,8 @@ public class CassandraConnectorConfig {
     }
 
     public boolean tombstonesOnDelete() {
-        return (boolean) configs.getOrDefault(TOMBSTONES_ON_DELETE, DEFAULT_TOMBSTONES_ON_DELETE);
+        return configs.containsKey(TOMBSTONES_ON_DELETE) ?
+                Boolean.parseBoolean((String) configs.get(TOMBSTONES_ON_DELETE)) : DEFAULT_TOMBSTONES_ON_DELETE;
     }
 
     @Override

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -237,6 +237,12 @@ public class CassandraConnectorConfig {
     public static final String LATEST_COMMIT_LOG_ONLY = "latest.commit.log.only";
     public static final boolean DEFAULT_LATEST_COMMIT_LOG_ONLY = false;
 
+    private Properties configs;
+
+    public CassandraConnectorConfig(Properties configs) {
+        this.configs = configs;
+    }
+
     public String connectorName() {
         return (String) configs.get(CONNECTOR_NAME);
     }
@@ -253,9 +259,9 @@ public class CassandraConnectorConfig {
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class);
 
         configs.entrySet().stream()
-                .filter(entry -> entry.getKey().startsWith(KAFKA_PRODUCER_CONFIG_PREFIX))
+                .filter(entry -> entry.getKey().toString().startsWith(KAFKA_PRODUCER_CONFIG_PREFIX))
                 .forEach(entry -> {
-                    String k = entry.getKey().replace(KAFKA_PRODUCER_CONFIG_PREFIX, "");
+                    String k = entry.getKey().toString().replace(KAFKA_PRODUCER_CONFIG_PREFIX, "");
                     Object v = entry.getValue();
                     props.put(k, v);
                 });
@@ -266,19 +272,13 @@ public class CassandraConnectorConfig {
     public Properties commitLogTransferConfigs() {
         Properties props = new Properties();
         configs.entrySet().stream()
-                .filter(entry -> entry.getKey().startsWith(COMMIT_LOG_TRANSFER_CONFIG_PREFIX))
+                .filter(entry -> entry.getKey().toString().startsWith(COMMIT_LOG_TRANSFER_CONFIG_PREFIX))
                 .forEach(entry -> props.put(entry.getKey(), entry.getValue()));
         return props;
     }
 
     public boolean latestCommitLogOnly() {
         return (boolean) configs.getOrDefault(LATEST_COMMIT_LOG_ONLY, DEFAULT_LATEST_COMMIT_LOG_ONLY);
-    }
-
-    private Map<String, Object> configs;
-
-    public CassandraConnectorConfig(Map<String, Object> configs) {
-        this.configs = configs;
     }
 
     public SnapshotMode snapshotMode() {
@@ -400,7 +400,7 @@ public class CassandraConnectorConfig {
     @Override
     public String toString() {
         return configs.entrySet().stream()
-                .filter(e -> !e.getKey().toLowerCase().contains("username") && !e.getKey().toLowerCase().contains("password"))
+                .filter(e -> !e.getKey().toString().toLowerCase().contains("username") && !e.getKey().toString().toLowerCase().contains("password"))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
                 .toString();
     }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
@@ -18,7 +18,6 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -29,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.Properties;
 
 /**
  * A task that reads Cassandra commit log in CDC directory and generate corresponding data
@@ -54,7 +54,9 @@ public class CassandraConnectorTask {
 
         String configPath = args[0];
         try (FileInputStream fis = new FileInputStream(configPath)) {
-            Map<String, Object> props = new Yaml().load(fis);
+            Properties props = new Properties();
+            props.load(fis);
+            fis.close();
             CassandraConnectorConfig config = new CassandraConnectorConfig(props);
             CassandraConnectorTask task = new CassandraConnectorTask(config);
             task.run();

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/network/SslConfig.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/network/SslConfig.java
@@ -5,7 +5,7 @@
  */
 package io.debezium.connector.cassandra.network;
 
-import java.util.Map;
+import java.util.Properties;
 
 public class SslConfig {
 
@@ -25,9 +25,9 @@ public class SslConfig {
     public static final String TRUST_MANAGER_ALGORITHM = "trustManager.algorithm";
     public static final String DEFAULT_TRUST_MANAGER_ALGORITHM = "SunX509";
 
-    private Map<String, Object> configs;
+    private Properties configs;
 
-    public SslConfig(Map<String, Object> configs) {
+    public SslConfig(Properties configs) {
         this.configs = configs;
     }
 

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/network/SslContextFactory.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/network/SslContextFactory.java
@@ -12,7 +12,6 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
@@ -20,6 +19,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.util.Properties;
 
 public class SslContextFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(SslContextFactory.class);
@@ -27,7 +27,7 @@ public class SslContextFactory {
 
     /**
      * Return an {@link SslContext} containing all SSL configurations parsed
-     * from the YAML file path
+     * from the Properties file path
      * <p>
      * See {@link SslConfig} class for a list of valid config names
      *
@@ -38,9 +38,11 @@ public class SslContextFactory {
         if (sslConfigPath == null) {
             throw new CassandraConnectorConfigException("Please specify SSL config path in cdc.yml");
         }
-        Yaml yaml = new Yaml();
+        Properties props = new Properties();
         try (FileInputStream fis = new FileInputStream(sslConfigPath)) {
-            SslConfig sslConfig = new SslConfig(yaml.load(fis));
+            props.load(fis);
+            fis.close();
+            SslConfig sslConfig = new SslConfig(props);
             return createSslContext(sslConfig);
         }
     }

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
@@ -31,7 +31,7 @@ public class CassandraConnectorConfigTest {
         assertEquals(snapshotConsistency, config.snapshotConsistencyLevel().name().toUpperCase());
 
         int port = 1234;
-        config = buildTaskConfig(CassandraConnectorConfig.HTTP_PORT, port);
+        config = buildTaskConfig(CassandraConnectorConfig.HTTP_PORT, String.valueOf(port));
         assertEquals(port, config.httpPort());
 
         String cassandraConfig = "cassandra-unit.yaml";
@@ -43,7 +43,7 @@ public class CassandraConnectorConfigTest {
         assertArrayEquals(cassandraHosts.split(","), config.cassandraHosts());
 
         int cassandraPort = 9412;
-        config = buildTaskConfig(CassandraConnectorConfig.CASSANDRA_PORT, cassandraPort);
+        config = buildTaskConfig(CassandraConnectorConfig.CASSANDRA_PORT, String.valueOf(cassandraPort));
         assertEquals(cassandraPort, config.cassandraPort());
 
         String cassandraUsername = "test_user";
@@ -54,7 +54,7 @@ public class CassandraConnectorConfigTest {
         config = buildTaskConfig(CassandraConnectorConfig.CASSANDRA_PASSWORD, cassandraPassword);
         assertEquals(cassandraPassword, config.cassandraPassword());
 
-        config = buildTaskConfig(CassandraConnectorConfig.CASSANDRA_SSL_ENABLED, true);
+        config = buildTaskConfig(CassandraConnectorConfig.CASSANDRA_SSL_ENABLED, "true");
         assertTrue(config.cassandraSslEnabled());
 
         String cassandraSslConfigPath = "/some/path/";
@@ -74,42 +74,42 @@ public class CassandraConnectorConfigTest {
         assertEquals(offsetBackingStore, config.offsetBackingStoreDir());
 
         int offsetFlushIntervalMs = 1234;
-        config = buildTaskConfig(CassandraConnectorConfig.OFFSET_FLUSH_INTERVAL_MS, offsetFlushIntervalMs);
+        config = buildTaskConfig(CassandraConnectorConfig.OFFSET_FLUSH_INTERVAL_MS, String.valueOf(offsetFlushIntervalMs));
         assertEquals(offsetFlushIntervalMs, config.offsetFlushIntervalMs().toMillis());
 
         int offsetMaxFlushSize = 200;
-        config = buildTaskConfig(CassandraConnectorConfig.MAX_OFFSET_FLUSH_SIZE, offsetMaxFlushSize);
+        config = buildTaskConfig(CassandraConnectorConfig.MAX_OFFSET_FLUSH_SIZE, String.valueOf(offsetMaxFlushSize));
         assertEquals(offsetMaxFlushSize, config.maxOffsetFlushSize());
 
         int maxQueueSize = 500;
-        config = buildTaskConfig(CassandraConnectorConfig.MAX_QUEUE_SIZE, maxQueueSize);
+        config = buildTaskConfig(CassandraConnectorConfig.MAX_QUEUE_SIZE, String.valueOf(maxQueueSize));
         assertEquals(maxQueueSize, config.maxQueueSize());
 
         int maxBatchSize = 500;
-        config = buildTaskConfig(CassandraConnectorConfig.MAX_BATCH_SIZE, maxBatchSize);
+        config = buildTaskConfig(CassandraConnectorConfig.MAX_BATCH_SIZE, String.valueOf(maxBatchSize));
         assertEquals(maxBatchSize, config.maxBatchSize());
 
         int pollIntervalMs = 500;
-        config = buildTaskConfig(CassandraConnectorConfig.POLL_INTERVAL_MS, pollIntervalMs);
+        config = buildTaskConfig(CassandraConnectorConfig.POLL_INTERVAL_MS, String.valueOf(pollIntervalMs));
         assertEquals(pollIntervalMs, config.pollIntervalMs().toMillis());
 
         int schemaPollIntervalMs = 500;
-        config = buildTaskConfig(CassandraConnectorConfig.SCHEMA_POLL_INTERVAL_MS, schemaPollIntervalMs);
+        config = buildTaskConfig(CassandraConnectorConfig.SCHEMA_POLL_INTERVAL_MS, String.valueOf(schemaPollIntervalMs));
         assertEquals(schemaPollIntervalMs, config.schemaPollIntervalMs().toMillis());
 
         int cdcDirPollIntervalMs = 500;
-        config = buildTaskConfig(CassandraConnectorConfig.CDC_DIR_POLL_INTERVAL_MS, cdcDirPollIntervalMs);
+        config = buildTaskConfig(CassandraConnectorConfig.CDC_DIR_POLL_INTERVAL_MS, String.valueOf(cdcDirPollIntervalMs));
         assertEquals(cdcDirPollIntervalMs, config.cdcDirPollIntervalMs().toMillis());
 
         int snapshotPollIntervalMs = 500;
-        config = buildTaskConfig(CassandraConnectorConfig.SNAPSHOT_POLL_INTERVAL_MS, snapshotPollIntervalMs);
+        config = buildTaskConfig(CassandraConnectorConfig.SNAPSHOT_POLL_INTERVAL_MS, String.valueOf(snapshotPollIntervalMs));
         assertEquals(snapshotPollIntervalMs, config.snapshotPollIntervalMs().toMillis());
 
         String fieldBlacklist = "keyspace1.table1.column1,keyspace1.table1.column2";
         config = buildTaskConfig(CassandraConnectorConfig.FIELD_BLACKLIST, fieldBlacklist);
         assertArrayEquals(fieldBlacklist.split(","), config.fieldBlacklist());
 
-        config = buildTaskConfig(CassandraConnectorConfig.TOMBSTONES_ON_DELETE, true);
+        config = buildTaskConfig(CassandraConnectorConfig.TOMBSTONES_ON_DELETE, "true");
         assertTrue(config.tombstonesOnDelete());
 
         String snapshotMode = "always";
@@ -120,9 +120,8 @@ public class CassandraConnectorConfigTest {
         config = buildTaskConfig(CassandraConnectorConfig.COMMIT_LOG_RELOCATION_DIR, commitLogDir);
         assertEquals(commitLogDir, config.commitLogRelocationDir());
 
-        boolean shouldPostProcess = false;
-        config = buildTaskConfig(CassandraConnectorConfig.COMMIT_LOG_POST_PROCESSING_ENABLED, shouldPostProcess);
-        assertEquals(shouldPostProcess, config.postProcessEnabled());
+        config = buildTaskConfig(CassandraConnectorConfig.COMMIT_LOG_POST_PROCESSING_ENABLED, "false");
+        assertEquals(false, config.postProcessEnabled());
 
         String transferClazz = "io.debezium.connector.cassandra.BlackHoleCommitLogTransfer";
         config = buildTaskConfig(CassandraConnectorConfig.COMMIT_LOG_TRANSFER_CLASS, transferClazz);
@@ -156,6 +155,7 @@ public class CassandraConnectorConfigTest {
         assertFalse(config.cassandraSslEnabled());
         assertFalse(config.tombstonesOnDelete());
         assertEquals(CassandraConnectorConfig.SnapshotMode.INITIAL, config.snapshotMode());
+        assertEquals(CassandraConnectorConfig.DEFAULT_LATEST_COMMIT_LOG_ONLY, config.latestCommitLogOnly());
     }
 
     @Test

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
@@ -7,8 +7,7 @@ package io.debezium.connector.cassandra;
 
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.Properties;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -131,13 +130,15 @@ public class CassandraConnectorConfigTest {
     }
 
     private CassandraConnectorConfig buildTaskConfig(String key, Object value) {
-        Map<String, Object> map = Collections.singletonMap(key, value);
-        return new CassandraConnectorConfig(map);
+        Properties props = new Properties();
+        props.put(key, value);
+        return new CassandraConnectorConfig(props);
     }
 
     @Test
     public void testDefaultConfigs() {
-        CassandraConnectorConfig config = new CassandraConnectorConfig(Collections.emptyMap());
+        Properties props = new Properties();
+        CassandraConnectorConfig config = new CassandraConnectorConfig(props);
         assertEquals(CassandraConnectorConfig.DEFAULT_SNAPSHOT_CONSISTENCY, config.snapshotConsistencyLevel().name().toUpperCase());
         assertEquals(CassandraConnectorConfig.DEFAULT_HTTP_PORT, config.httpPort());
         assertArrayEquals(CassandraConnectorConfig.DEFAULT_CASSANDRA_HOST.split(","), config.cassandraHosts());

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/EmbeddedCassandraConnectorTestBase.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/EmbeddedCassandraConnectorTestBase.java
@@ -23,8 +23,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Base class used to automatically spin up a single-node embedded Cassandra cluster before tests
@@ -75,7 +75,7 @@ public abstract class EmbeddedCassandraConnectorTestBase {
      * Generate a task context with default test configs
      */
     protected static CassandraConnectorContext generateTaskContext() throws GeneralSecurityException, IOException {
-        Map<String, Object> defaults = generateDefaultConfigMap();
+        Properties defaults = generateDefaultConfigMap();
         return new CassandraConnectorContext(new CassandraConnectorConfig(defaults));
     }
 
@@ -83,7 +83,7 @@ public abstract class EmbeddedCassandraConnectorTestBase {
      * General a task context with default and custom test configs
      */
     protected static CassandraConnectorContext generateTaskContext(Map<String, Object> configs) throws GeneralSecurityException, IOException {
-        Map<String, Object> defaults = generateDefaultConfigMap();
+        Properties defaults = generateDefaultConfigMap();
         defaults.putAll(configs);
         return new CassandraConnectorContext(new CassandraConnectorConfig(defaults));
     }
@@ -165,18 +165,18 @@ public abstract class EmbeddedCassandraConnectorTestBase {
         }
     }
 
-    protected static Map<String, Object> generateDefaultConfigMap() throws IOException {
-        Map<String, Object> configs = new HashMap<>();
-        configs.put(CassandraConnectorConfig.CONNECTOR_NAME, TEST_CONNECTOR_NAME);
-        configs.put(CassandraConnectorConfig.CASSANDRA_CONFIG, TEST_CASSANDRA_YAML_CONFIG);
-        configs.put(CassandraConnectorConfig.KAFKA_TOPIC_PREFIX, TEST_KAFKA_TOPIC_PREFIX);
-        configs.put(CassandraConnectorConfig.CASSANDRA_HOSTS, TEST_CASSANDRA_HOSTS);
-        configs.put(CassandraConnectorConfig.CASSANDRA_PORT, TEST_CASSANDRA_PORT);
-        configs.put(CassandraConnectorConfig.OFFSET_BACKING_STORE_DIR, Files.createTempDirectory("offset").toString());
-        configs.put(CassandraConnectorConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, TEST_KAFKA_SERVERS);
-        configs.put(CassandraConnectorConfig.KAFKA_PRODUCER_CONFIG_PREFIX + AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, TEST_SCHEMA_REGISTRY_URL);
-        configs.put(CassandraConnectorConfig.COMMIT_LOG_RELOCATION_DIR, Files.createTempDirectory("cdc_raw_relocation").toString());
-        return configs;
+    protected static Properties generateDefaultConfigMap() throws IOException {
+        Properties props = new Properties();
+        props.put(CassandraConnectorConfig.CONNECTOR_NAME, TEST_CONNECTOR_NAME);
+        props.put(CassandraConnectorConfig.CASSANDRA_CONFIG, TEST_CASSANDRA_YAML_CONFIG);
+        props.put(CassandraConnectorConfig.KAFKA_TOPIC_PREFIX, TEST_KAFKA_TOPIC_PREFIX);
+        props.put(CassandraConnectorConfig.CASSANDRA_HOSTS, TEST_CASSANDRA_HOSTS);
+        props.put(CassandraConnectorConfig.CASSANDRA_PORT, TEST_CASSANDRA_PORT);
+        props.put(CassandraConnectorConfig.OFFSET_BACKING_STORE_DIR, Files.createTempDirectory("offset").toString());
+        props.put(CassandraConnectorConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, TEST_KAFKA_SERVERS);
+        props.put(CassandraConnectorConfig.KAFKA_PRODUCER_CONFIG_PREFIX + AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, TEST_SCHEMA_REGISTRY_URL);
+        props.put(CassandraConnectorConfig.COMMIT_LOG_RELOCATION_DIR, Files.createTempDirectory("cdc_raw_relocation").toString());
+        return props;
     }
 
     private static void startEmbeddedCassandra() throws Exception {

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/EmbeddedCassandraConnectorTestBase.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/EmbeddedCassandraConnectorTestBase.java
@@ -171,7 +171,7 @@ public abstract class EmbeddedCassandraConnectorTestBase {
         props.put(CassandraConnectorConfig.CASSANDRA_CONFIG, TEST_CASSANDRA_YAML_CONFIG);
         props.put(CassandraConnectorConfig.KAFKA_TOPIC_PREFIX, TEST_KAFKA_TOPIC_PREFIX);
         props.put(CassandraConnectorConfig.CASSANDRA_HOSTS, TEST_CASSANDRA_HOSTS);
-        props.put(CassandraConnectorConfig.CASSANDRA_PORT, TEST_CASSANDRA_PORT);
+        props.put(CassandraConnectorConfig.CASSANDRA_PORT, String.valueOf(TEST_CASSANDRA_PORT));
         props.put(CassandraConnectorConfig.OFFSET_BACKING_STORE_DIR, Files.createTempDirectory("offset").toString());
         props.put(CassandraConnectorConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, TEST_KAFKA_SERVERS);
         props.put(CassandraConnectorConfig.KAFKA_PRODUCER_CONFIG_PREFIX + AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, TEST_SCHEMA_REGISTRY_URL);

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/SnapshotProcessorTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/SnapshotProcessorTest.java
@@ -111,7 +111,7 @@ public class SnapshotProcessorTest extends EmbeddedCassandraConnectorTestBase {
     public void testSnapshotModeAlways() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put(CassandraConnectorConfig.SNAPSHOT_MODE, "always");
-        configs.put(CassandraConnectorConfig.SNAPSHOT_POLL_INTERVAL_MS, 0);
+        configs.put(CassandraConnectorConfig.SNAPSHOT_POLL_INTERVAL_MS, "0");
         CassandraConnectorContext context = generateTaskContext(configs);
         SnapshotProcessor snapshotProcessorSpy = Mockito.spy(new SnapshotProcessor(context));
         doNothing().when(snapshotProcessorSpy).snapshot();
@@ -128,7 +128,7 @@ public class SnapshotProcessorTest extends EmbeddedCassandraConnectorTestBase {
     public void testSnapshotModeInitial() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put(CassandraConnectorConfig.SNAPSHOT_MODE, "initial");
-        configs.put(CassandraConnectorConfig.SNAPSHOT_POLL_INTERVAL_MS, 0);
+        configs.put(CassandraConnectorConfig.SNAPSHOT_POLL_INTERVAL_MS, "0");
         CassandraConnectorContext context = generateTaskContext(configs);
         SnapshotProcessor snapshotProcessorSpy = Mockito.spy(new SnapshotProcessor(context));
         doNothing().when(snapshotProcessorSpy).snapshot();
@@ -145,7 +145,7 @@ public class SnapshotProcessorTest extends EmbeddedCassandraConnectorTestBase {
     public void testSnapshotModeNever() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put(CassandraConnectorConfig.SNAPSHOT_MODE, "never");
-        configs.put(CassandraConnectorConfig.SNAPSHOT_POLL_INTERVAL_MS, 0);
+        configs.put(CassandraConnectorConfig.SNAPSHOT_POLL_INTERVAL_MS, "0");
         CassandraConnectorContext context = generateTaskContext(configs);
         SnapshotProcessor snapshotProcessorSpy = Mockito.spy(new SnapshotProcessor(context));
         doNothing().when(snapshotProcessorSpy).snapshot();


### PR DESCRIPTION
Use Property file instead of Yaml file for Cassandra Connector Config to get rid of SnakeYaml dependency.