### PR TITLE
DBZ-1555 TableId parts precedence is configurable

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -121,7 +121,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final OracleVersion oracleVersion;
 
     public OracleConnectorConfig(Configuration config) {
-        super(config, config.getString(SERVER_NAME), new SystemTablesPredicate());
+        super(config, config.getString(SERVER_NAME), new SystemTablesPredicate(), true);
 
         this.databaseName = config.getString(DATABASE_NAME);
         this.pdbName = config.getString(PDB_NAME);


### PR DESCRIPTION
@gunnarmorling There is a core API compatibility break