### PR TITLE
DBZ-1631 - alter select to perform timestamp_to_scn on most recent

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -158,7 +158,7 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
             return Optional.empty();
         }
 
-        StringBuilder lastDdlScnQuery = new StringBuilder("SELECT MAX(TIMESTAMP_TO_SCN(last_ddl_time))")
+        StringBuilder lastDdlScnQuery = new StringBuilder("SELECT TIMESTAMP_TO_SCN(MAX(last_ddl_time))")
                 .append(" FROM all_objects")
                 .append(" WHERE");
 


### PR DESCRIPTION
Fix attempting to retrieve an SCN for all last_ddl_times, instead get most recent ddl_time and the SCN for that. Functionally equivalent, but won't fail when there's no snapshots for old ddls (on a pre-existing db for example)