### PR TITLE
[DBZ-1763] Replace connectorName with kafkaTopicPrefix for kafka key/value schema namespace.

### DIFF
--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorContext.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorContext.java
@@ -35,7 +35,7 @@ public class CassandraConnectorContext {
         this.queue = new BlockingEventQueue<>(this.config.pollIntervalMs(), this.config.maxQueueSize(), this.config.maxBatchSize());
 
         // Setting up schema holder ...
-        this.schemaHolder = new SchemaHolder(this.cassandraClient, this.config.connectorName(), this.config.getSourceInfoStructMaker());
+        this.schemaHolder = new SchemaHolder(this.cassandraClient, this.config.kafkaTopicPrefix(), this.config.getSourceInfoStructMaker());
 
         // Setting up a file-based offset manager ...
         this.offsetWriter = new FileOffsetWriter(this.config.offsetBackingStoreDir());

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/SchemaProcessorTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/SchemaProcessorTest.java
@@ -31,8 +31,7 @@ public class SchemaProcessorTest extends EmbeddedCassandraConnectorTestBase {
         context.getCassandraClient().execute("CREATE TABLE IF NOT EXISTS " + keyspaceTable("table1") + " (a int, b text, PRIMARY KEY(a)) WITH cdc = false;");
         schemaProcessor.process();
         assertEquals(0, context.getSchemaHolder().getCdcEnabledTableMetadataSet().size());
-        keyValueSchema = context.getSchemaHolder().getOrUpdateKeyValueSchema(new KeyspaceTable(TEST_KEYSPACE, "table1"));
-        assertNull(keyValueSchema);
+        assertNull(context.getSchemaHolder().getOrUpdateKeyValueSchema(new KeyspaceTable(TEST_KEYSPACE, "table1")));
 
         context.getCassandraClient().execute("ALTER TABLE " + keyspaceTable("table1") + " WITH cdc = true;");
         schemaProcessor.process();


### PR DESCRIPTION
Use `kafkaTopicPrefix` which is actually the logical cluster name in kafka key/value namespace instead of `connectorName`, otherwise, different cassandra-cdc connectors deployed on different cassandra nodes will produce different kafka key/value schemas for one same kafka topic and cause downstream kcbq to fail.