### PR TITLE
DBZ-1752 DB2 connector follow-up tasks

### DIFF
--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -37,7 +37,7 @@ import io.debezium.relational.history.KafkaDatabaseHistory;
 /**
  * The list of configuration options for DB2 connector
  *
- * @author Jiri Pechanec
+ * @author Jiri Pechanec, Luis Garcés-Erice
  */
 public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorConfig {
 
@@ -118,6 +118,8 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
 
     /**
      * The set of predefined snapshot isolation mode options.
+     * 
+     * https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.5.0/com.ibm.db2.luw.apdv.java.doc/src/tpc/imjcc_r0052429.html
      */
     public static enum SnapshotIsolationMode implements EnumeratedValue {
 
@@ -129,18 +131,19 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         EXCLUSIVE("exclusive"),
 
         /**
-         * This mode uses SNAPSHOT isolation level. This way reads and writes are not blocked for the entire duration
-         * of the snapshot.  Snapshot consistency is guaranteed as long as DDL statements are not executed at the time.
-         */
-        SNAPSHOT("snapshot"),
-
-        /**
          * This mode uses REPEATABLE READ isolation level. This mode will avoid taking any table
          * locks during the snapshot process, except schema snapshot phase where exclusive table
          * locks are acquired for a short period.  Since phantom reads can occur, it does not fully
          * guarantee consistency.
          */
         REPEATABLE_READ("repeatable_read"),
+
+        /**
+         * This mode uses READ COMMITTED isolation level. This mode does not take any table locks during
+         * the snapshot process. In addition, it does not take any long-lasting row-level locks, like
+         * in repeatable read isolation level. Snapshot consistency is not guaranteed.
+         */
+        READ_COMMITTED("read_committed"),
 
         /**
          * This mode uses READ UNCOMMITTED isolation level. This mode takes neither table locks nor row-level locks
@@ -226,8 +229,8 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
                     + "', which means that repeatable read isolation level is used. In addition, exclusive locks are taken only during schema snapshot. "
                     + "Using a value of '" + SnapshotIsolationMode.EXCLUSIVE.getValue()
                     + "' ensures that the connector holds the exclusive lock (and thus prevents any reads and updates) for all monitored tables during the entire snapshot duration. "
-                    + "When '" + SnapshotIsolationMode.SNAPSHOT.getValue()
-                    + "' is specified, connector runs the initial snapshot in SNAPSHOT isolation level, which guarantees snapshot consistency. In addition, neither table nor row-level locks are held. "
+                    + "In '" + SnapshotIsolationMode.READ_COMMITTED.getValue()
+                    + "' mode no table locks or any *long-lasting* row-level locks are acquired, but connector does not guarantee snapshot consistency."
                     + "In '" + SnapshotIsolationMode.READ_UNCOMMITTED.getValue()
                     + "' mode neither table nor row-level locks are acquired, but connector does not guarantee snapshot consistency.");
 

--- a/debezium-connector-db2/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
+++ b/debezium-connector-db2/src/test/java/io/debezium/connector/db2/Db2ConnectorIT.java
@@ -100,7 +100,7 @@ public class Db2ConnectorIT extends AbstractConnectorTest {
 
         TestHelper.refreshAndWait(connection);
 
-        final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
+        consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
 
         connection.execute("DELETE FROM tableB");
 
@@ -118,7 +118,6 @@ public class Db2ConnectorIT extends AbstractConnectorTest {
                     new SchemaAndValueField("ID", Schema.INT32_SCHEMA, i + ID_START),
                     new SchemaAndValueField("COLB", Schema.OPTIONAL_STRING_SCHEMA, "b"));
 
-            final Struct deleteKey = (Struct) deleteRecord.key();
             final Struct deleteValue = (Struct) deleteRecord.value();
             assertRecord((Struct) deleteValue.get("before"), expectedDeleteRow);
             assertNull(deleteValue.get("after"));


### PR DESCRIPTION
This pull request addresses:
- Use only DB2 compatible isolation modes when taking Snapshots
- Remove some unused variables