### PR TITLE
DBZ-1795 Fix link to CONTRIBUTE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ Making this configuration obsolete is tracked under [DBZ-1045](https://issues.jb
 
 ## Contributing
 
-The Debezium community welcomes anyone that wants to help out in any way, whether that includes reporting problems, helping with documentation, or contributing code changes to fix bugs, add tests, or implement new features. See [this document](CONTRIBUTE.md) for details.
+The Debezium community welcomes anyone that wants to help out in any way, whether that includes reporting problems, helping with documentation, or contributing code changes to fix bugs, add tests, or implement new features. See [this document](https://github.com/debezium/debezium/blob/master/CONTRIBUTE.md) for details.


### PR DESCRIPTION
Fixes the link to CONTRIBUTE.md in debezium-incubator repository README.md

https://issues.redhat.com/browse/DBZ-1795