### PR TITLE
DBZ-1892 Fix wrong sourceInfo in Cassandra CDC Kafka messages

### DIFF
--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
@@ -51,7 +51,7 @@ public class CommitLogProcessor extends AbstractProcessor {
                 context.getOffsetWriter(),
                 new RecordMaker(context.getCassandraConnectorConfig().tombstonesOnDelete(),
                         new Filters(context.getCassandraConnectorConfig().fieldBlacklist()),
-                        new SourceInfo(context.getCassandraConnectorConfig())),
+                        context.getCassandraConnectorConfig()),
                 metrics);
         cdcDir = new File(DatabaseDescriptor.getCDCLogLocation());
         watcher = new AbstractDirectoryWatcher(cdcDir.toPath(), context.getCassandraConnectorConfig().cdcDirPollIntervalMs(), Collections.singleton(ENTRY_CREATE)) {

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogReadHandlerImpl.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogReadHandlerImpl.java
@@ -331,9 +331,9 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
                 after.addCell(cellData);
             }
 
-            recordMaker.getSourceInfo().update(DatabaseDescriptor.getClusterName(), offsetPosition, keyspaceTable, false,
-                    Conversions.toInstantFromMicros(pu.maxTimestamp()));
-            recordMaker.delete(after, keySchema, valueSchema, MARK_OFFSET, queue::enqueue);
+            recordMaker.delete(DatabaseDescriptor.getClusterName(), offsetPosition, keyspaceTable, false,
+                    Conversions.toInstantFromMicros(pu.maxTimestamp()), after, keySchema, valueSchema,
+                    MARK_OFFSET, queue::enqueue);
         }
         catch (Exception e) {
             LOGGER.error("Fail to delete partition at {}. Reason: {}", offsetPosition, e);
@@ -367,19 +367,21 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
         populateRegularColumns(after, row, rowType, schema);
 
         long ts = rowType == DELETE ? row.deletion().time().markedForDeleteAt() : pu.maxTimestamp();
-        recordMaker.getSourceInfo().update(DatabaseDescriptor.getClusterName(), offsetPosition, keyspaceTable, false, Conversions.toInstantFromMicros(ts));
 
         switch (rowType) {
             case INSERT:
-                recordMaker.insert(after, keySchema, valueSchema, MARK_OFFSET, queue::enqueue);
+                recordMaker.insert(DatabaseDescriptor.getClusterName(), offsetPosition, keyspaceTable, false,
+                        Conversions.toInstantFromMicros(ts), after, keySchema, valueSchema, MARK_OFFSET, queue::enqueue);
                 break;
 
             case UPDATE:
-                recordMaker.update(after, keySchema, valueSchema, MARK_OFFSET, queue::enqueue);
+                recordMaker.update(DatabaseDescriptor.getClusterName(), offsetPosition, keyspaceTable, false,
+                        Conversions.toInstantFromMicros(ts), after, keySchema, valueSchema, MARK_OFFSET, queue::enqueue);
                 break;
 
             case DELETE:
-                recordMaker.delete(after, keySchema, valueSchema, MARK_OFFSET, queue::enqueue);
+                recordMaker.delete(DatabaseDescriptor.getClusterName(), offsetPosition, keyspaceTable, false,
+                        Conversions.toInstantFromMicros(ts), after, keySchema, valueSchema, MARK_OFFSET, queue::enqueue);
                 break;
 
             default:

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/RecordMaker.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/RecordMaker.java
@@ -5,14 +5,14 @@
  */
 package io.debezium.connector.cassandra;
 
+import java.time.Instant;
+
 import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.cassandra.exceptions.CassandraConnectorTaskException;
 import io.debezium.function.BlockingConsumer;
-
-import java.time.Instant;
 
 /**
  * Responsible for generating ChangeRecord and/or TombstoneRecord for create/update/delete events, as well as EOF events.

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/SourceInfo.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/SourceInfo.java
@@ -35,11 +35,9 @@ public class SourceInfo extends AbstractSourceInfo {
     public boolean snapshot;
     public Instant tsMicro;
 
-    public SourceInfo(CommonConnectorConfig config) {
+    public SourceInfo(CommonConnectorConfig config, String cluster, OffsetPosition offsetPosition,
+                      KeyspaceTable keyspaceTable, boolean snapshot, Instant tsMicro) {
         super(config);
-    }
-
-    public void update(String cluster, OffsetPosition offsetPosition, KeyspaceTable keyspaceTable, boolean snapshot, Instant tsMicro) {
         this.cluster = cluster;
         this.offsetPosition = offsetPosition;
         this.keyspaceTable = keyspaceTable;

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/FileOffsetWriterTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/FileOffsetWriterTest.java
@@ -129,8 +129,8 @@ public class FileOffsetWriterTest {
 
     private ChangeRecord generateRecord(boolean markOffset, boolean isSnapshot, OffsetPosition offsetPosition, KeyspaceTable keyspaceTable) {
         CassandraConnectorConfig config = new CassandraConnectorConfig(Configuration.from(new Properties()));
-        SourceInfo sourceInfo = new SourceInfo(config);
-        sourceInfo.update("test-cluster", offsetPosition, keyspaceTable, isSnapshot, Conversions.toInstantFromMicros(System.currentTimeMillis() * 1000));
+        SourceInfo sourceInfo = new SourceInfo(config, "test-cluster", offsetPosition, keyspaceTable,
+                isSnapshot, Conversions.toInstantFromMicros(System.currentTimeMillis() * 1000));
         return new ChangeRecord(sourceInfo, new RowData(), Schema.INT32_SCHEMA, Schema.INT32_SCHEMA, Record.Operation.INSERT, markOffset);
     }
 

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/QueueProcessorTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/QueueProcessorTest.java
@@ -50,8 +50,9 @@ public class QueueProcessorTest extends EmbeddedCassandraConnectorTestBase {
         ChangeEventQueue<Event> queue = context.getQueue();
         for (int i = 0; i < recordSize; i++) {
             CassandraConnectorConfig config = new CassandraConnectorConfig(Configuration.from(new Properties()));
-            SourceInfo sourceInfo = new SourceInfo(config);
-            sourceInfo.update(DatabaseDescriptor.getClusterName(), new OffsetPosition("CommitLog-6-123.log", i), new KeyspaceTable(TEST_KEYSPACE, "cdc_table"), false,
+            SourceInfo sourceInfo = new SourceInfo(config, DatabaseDescriptor.getClusterName(),
+                    new OffsetPosition("CommitLog-6-123.log", i),
+                    new KeyspaceTable(TEST_KEYSPACE, "cdc_table"), false,
                     Conversions.toInstantFromMicros(System.currentTimeMillis() * 1000));
             Record record = new ChangeRecord(sourceInfo, new RowData(), Schema.INT32_SCHEMA, Schema.INT32_SCHEMA, Record.Operation.INSERT, false);
             queue.enqueue(record);
@@ -71,8 +72,9 @@ public class QueueProcessorTest extends EmbeddedCassandraConnectorTestBase {
         ChangeEventQueue<Event> queue = context.getQueue();
         for (int i = 0; i < recordSize; i++) {
             CassandraConnectorConfig config = new CassandraConnectorConfig(Configuration.from(new Properties()));
-            SourceInfo sourceInfo = new SourceInfo(config);
-            sourceInfo.update(DatabaseDescriptor.getClusterName(), new OffsetPosition("CommitLog-6-123.log", i), new KeyspaceTable(TEST_KEYSPACE, "cdc_table"), false,
+            SourceInfo sourceInfo = new SourceInfo(config, DatabaseDescriptor.getClusterName(),
+                    new OffsetPosition("CommitLog-6-123.log", i),
+                    new KeyspaceTable(TEST_KEYSPACE, "cdc_table"), false,
                     Conversions.toInstantFromMicros(System.currentTimeMillis() * 1000));
             Record record = new TombstoneRecord(sourceInfo, new RowData(), Schema.INT32_SCHEMA);
             queue.enqueue(record);


### PR DESCRIPTION
The PR is for fixing a critical bug that some change event or snapshot kafka messages published from Cassandra Connector for one table include wrong source info from another table.