### PR TITLE
Oracle connector integration tests poll jmx

### DIFF
--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/AbstractOracleDatatypesTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/AbstractOracleDatatypesTest.java
@@ -313,7 +313,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractConnectorTest 
         start(OracleConnector.class, config);
         assertConnectorIsRunning();
 
-        Thread.sleep(2000);
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
         int expectedRecordCount = 0;
 
@@ -356,7 +356,7 @@ public abstract class AbstractOracleDatatypesTest extends AbstractConnectorTest 
         start(OracleConnector.class, config);
         assertConnectorIsRunning();
 
-        Thread.sleep(2000);
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
         int expectedRecordCount = 0;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorFilterIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorFilterIT.java
@@ -111,7 +111,7 @@ public class OracleConnectorFilterIT extends AbstractConnectorTest {
         start(OracleConnector.class, config);
         assertConnectorIsRunning();
 
-        Thread.sleep(1000);
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
         connection.execute("INSERT INTO debezium.table1 VALUES (1, 'Text-1')");
         connection.execute("INSERT INTO debezium.table2 VALUES (2, 'Text-2')");
@@ -163,7 +163,7 @@ public class OracleConnectorFilterIT extends AbstractConnectorTest {
         start(OracleConnector.class, config);
         assertConnectorIsRunning();
 
-        Thread.sleep(1000);
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
         connection.execute("INSERT INTO debezium.table1 VALUES (1, 'Text-1')");
         connection.execute("INSERT INTO debezium.table2 VALUES (2, 'Text-2')");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -376,7 +376,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
         start(OracleConnector.class, config);
         assertConnectorIsRunning();
 
-        Thread.sleep(1000);
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
         int expectedRecordCount = 0;
         connection.execute("INSERT INTO debezium.customer VALUES (1, 'Billie-Bob', 1234.56, TO_DATE('2018/02/22', 'yyyy-mm-dd'))");
@@ -467,7 +467,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
         start(OracleConnector.class, config);
         assertConnectorIsRunning();
 
-        Thread.sleep(1000);
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
         int expectedRecordCount = 0;
         connection.execute("INSERT INTO debezium.customer VALUES (1, 'Billie-Bob', 1234.56, TO_DATE('2018/02/22', 'yyyy-mm-dd'))");
@@ -509,7 +509,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
         start(OracleConnector.class, config);
         assertConnectorIsRunning();
 
-        Thread.sleep(1000);
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
         String ddl = "create table debezium.customer2 (" +
                 "  id numeric(9,0) not null, " +
@@ -554,7 +554,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
         start(OracleConnector.class, config);
         assertConnectorIsRunning();
 
-        Thread.sleep(1000);
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
         connection.execute("CREATE TABLE debezium.dbz800a (id NUMBER(9) NOT NULL, aaa VARCHAR2(100), PRIMARY KEY (id) )");
         connection.execute("CREATE TABLE debezium.dbz800b (id NUMBER(9) NOT NULL, bbb VARCHAR2(100), PRIMARY KEY (id) )");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SnapshotDatatypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SnapshotDatatypesIT.java
@@ -51,7 +51,7 @@ public class SnapshotDatatypesIT extends AbstractOracleDatatypesTest {
         start(OracleConnector.class, config);
         assertConnectorIsRunning();
 
-        Thread.sleep(2000);
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
     }
 
     protected Builder connectorConfig() {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/StreamingDatatypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/StreamingDatatypesIT.java
@@ -36,9 +36,7 @@ public class StreamingDatatypesIT extends AbstractOracleDatatypesTest {
         start(OracleConnector.class, config);
         assertConnectorIsRunning();
 
-        // wait until snapshotting has completed
-        // TODO add hook to embedded engine to reliably do this
-        Thread.sleep(2000);
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
         createTables();
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/TransactionMetadataIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/TransactionMetadataIT.java
@@ -82,7 +82,7 @@ public class TransactionMetadataIT extends AbstractConnectorTest {
         start(OracleConnector.class, config);
         assertConnectorIsRunning();
 
-        Thread.sleep(1000);
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
         // Testing.Print.enable();
         connection.execute("INSERT INTO debezium.customer VALUES (1, 'Billie-Bob', 1234.56, TO_DATE('2018/02/22', 'yyyy-mm-dd'))");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -28,6 +28,10 @@ public class TestHelper {
 
     public static final String CONNECTOR_USER = "c##xstrm";
 
+    public static final String CONNECTOR_NAME = "oracle";
+
+    public static final String SERVER_NAME = "server1";
+
     private static JdbcConfiguration defaultJdbcConfig() {
         return JdbcConfiguration.copy(Configuration.fromSystemProperties("database."))
                 .withDefault(JdbcConfiguration.HOSTNAME, "localhost")
@@ -49,7 +53,7 @@ public class TestHelper {
         jdbcConfiguration.forEach(
                 (field, value) -> builder.with(OracleConnectorConfig.DATABASE_CONFIG_PREFIX + field, value));
 
-        return builder.with(RelationalDatabaseConnectorConfig.SERVER_NAME, "server1")
+        return builder.with(RelationalDatabaseConnectorConfig.SERVER_NAME, SERVER_NAME)
                 .with(OracleConnectorConfig.PDB_NAME, "ORCLPDB1")
                 .with(OracleConnectorConfig.XSTREAM_SERVER_NAME, "dbzxout")
                 .with(OracleConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)


### PR DESCRIPTION
The oracle integration tests use a number of Thread.sleep() calls to wait for
the snapshotting phase to finish before testing streaming changes but sometimes
this can be unreliable, especially on a slow running db. Instead of sleeping,
polling the jmx metrics to watch for when the snapshot phase ends is preferable.