### PR TITLE
[DBZ-1927] Do not remove processed commitLog files under testing mode.

### DIFF
--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
@@ -109,11 +109,15 @@ public class CommitLogProcessor extends AbstractProcessor {
                 LOGGER.info("Processing commit log {}", file.getName());
                 metrics.setCommitLogFilename(file.getName());
                 commitLogReader.readCommitLogSegment(commitLogReadHandler, file, false);
-                queue.enqueue(new EOFEvent(file, true));
+                if (!latestOnly) {
+                    queue.enqueue(new EOFEvent(file, true));
+                }
                 LOGGER.info("Successfully processed commit log {}", file.getName());
             }
             catch (IOException e) {
-                queue.enqueue(new EOFEvent(file, false));
+                if (!latestOnly) {
+                    queue.enqueue(new EOFEvent(file, false));
+                }
                 LOGGER.warn("Error occurred while processing commit log " + file.getName(), e);
             }
         }


### PR DESCRIPTION
Cassandra Connector shouldn't remove commitLog files under testing mode (`latest.commit.log.only=true`).

Added a condition check to only enqueue EOF (end-of-file) event when not under testing mode, so that QueueProcess won't poll and process a corresponding EOF event to move the commitLog file to relocation directory.