### PR TITLE
[DBZ-1967] Fix the error for deserializing column mutation with reversed type.

### DIFF
--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogReadHandlerImpl.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogReadHandlerImpl.java
@@ -409,7 +409,7 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
                 after.addCell(cellData);
             }
             catch (Exception e) {
-                LOGGER.error("Failed to deserialize Column {} with Type {} in Table {} and KeySpace {}.",
+                LOGGER.debug("Failed to deserialize Column {} with Type {} in Table {} and KeySpace {}.",
                         cd.name.toString(), cd.type, cd.cfName, cd.ksName);
                 throw e;
             }
@@ -428,7 +428,7 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
                     after.addCell(cellData);
                 }
                 catch (Exception e) {
-                    LOGGER.error("Failed to deserialize Column {} with Type {} in Table {} and KeySpace {}.",
+                    LOGGER.debug("Failed to deserialize Column {} with Type {} in Table {} and KeySpace {}.",
                             cd.name.toString(), cd.type, cd.cfName, cd.ksName);
                     throw e;
                 }
@@ -471,7 +471,7 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
                 values.add(value);
             }
             catch (Exception e) {
-                LOGGER.error("Failed to deserialize Column {} with Type {} in Table {} and KeySpace {}.",
+                LOGGER.debug("Failed to deserialize Column {} with Type {} in Table {} and KeySpace {}.",
                         cs.name.toString(), cs.type, cs.cfName, cs.ksName);
                 throw e;
             }
@@ -506,7 +506,7 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
                     values.add(value);
                 }
                 catch (Exception e) {
-                    LOGGER.error("Failed to deserialize Column {} with Type {} in Table {} and KeySpace {}",
+                    LOGGER.debug("Failed to deserialize Column {} with Type {} in Table {} and KeySpace {}",
                             cs.name.toString(), cs.type, cs.cfName, cs.ksName);
                     throw e;
                 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/CassandraTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/CassandraTypeDeserializer.java
@@ -25,6 +25,7 @@ import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.ListType;
 import org.apache.cassandra.db.marshal.LongType;
 import org.apache.cassandra.db.marshal.MapType;
+import org.apache.cassandra.db.marshal.ReversedType;
 import org.apache.cassandra.db.marshal.SetType;
 import org.apache.cassandra.db.marshal.ShortType;
 import org.apache.cassandra.db.marshal.SimpleDateType;
@@ -116,6 +117,11 @@ public final class CassandraTypeDeserializer {
     public static Object deserialize(AbstractType<?> abstractType, ByteBuffer bb) {
         if (bb == null) {
             return null;
+        }
+
+        // Check if abstract type is reversed, if yes, use the base type for deserialization.
+        if (abstractType.isReversed()) {
+            abstractType = ((ReversedType) abstractType).baseType;
         }
 
         TypeDeserializer typeDeserializer = TYPE_MAP.get(abstractType.getClass());

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/transforms/CassandraTypeDeserializerTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/transforms/CassandraTypeDeserializerTest.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.ListType;
 import org.apache.cassandra.db.marshal.LongType;
 import org.apache.cassandra.db.marshal.MapType;
+import org.apache.cassandra.db.marshal.ReversedType;
 import org.apache.cassandra.db.marshal.SetType;
 import org.apache.cassandra.db.marshal.ShortType;
 import org.apache.cassandra.db.marshal.SimpleDateType;
@@ -424,5 +425,19 @@ public class CassandraTypeDeserializerTest {
         Object deserializedUUID = CassandraTypeDeserializer.deserialize(UUIDType.instance, serializedUUID);
 
         Assert.assertEquals(expectedFixedUUID, deserializedUUID);
+    }
+
+    @Test
+    public void testReversedType() {
+        Date timestamp = new Date();
+        Long expectedLongTimestamp = timestamp.getTime();
+
+        ByteBuffer serializedTimestamp = TimestampType.instance.decompose(timestamp);
+
+        ReversedType reversedTimeStampType = ReversedType.getInstance(TimestampType.instance);
+
+        Object deserializedTimestamp = CassandraTypeDeserializer.deserialize(reversedTimeStampType, serializedTimestamp);
+
+        Assert.assertEquals(expectedLongTimestamp, deserializedTimestamp);
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1967

For a column with DDL like `WITH CLUSTERING ORDER BY (event_time DESC)`, the abstract type of this column is wrapped with a ReversedType outside like
`org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.TimestampType)`, which causes deserialization to fail thus breaks commitLog processing in Cassandra Connector.

- Check if a type passed in for deserialization is a reversed type, if yes, use it's base type for deserialization.
- Add more detailed logs for debugging which column and type is failed to be deserialized.