### PR TITLE
[DBZ-1985] Fix Cassandra Connector stops processing new commitLogFiles in cdc_raw

### DIFF
--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/AbstractDirectoryWatcher.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/AbstractDirectoryWatcher.java
@@ -49,6 +49,7 @@ public abstract class AbstractDirectoryWatcher {
                     handleEvent(event, absolutePath);
                 }
             }
+            key.reset();
         }
     }
 

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/AbstractDirectoryWatcher.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/AbstractDirectoryWatcher.java
@@ -15,10 +15,15 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Wrapper class around WatchService to make WatchService re-usable and avoid code repetition
  */
 public abstract class AbstractDirectoryWatcher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDirectoryWatcher.class);
+
     private final WatchService watchService;
     private final Duration pollInterval;
     private final Path directory;
@@ -38,9 +43,11 @@ public abstract class AbstractDirectoryWatcher {
     }
 
     public void poll() throws InterruptedException, IOException {
+        LOGGER.debug("Polling commitLogFiles from cdc_raw directory...");
         WatchKey key = watchService.poll(pollInterval.toMillis(), TimeUnit.MILLISECONDS);
 
         if (key != null) {
+            LOGGER.debug("Detected new commitLogFiles in cdc_raw directory.");
             for (WatchEvent<?> event : key.pollEvents()) {
                 Path relativePath = (Path) event.context();
                 Path absolutePath = directory.resolve(relativePath);
@@ -50,6 +57,9 @@ public abstract class AbstractDirectoryWatcher {
                 }
             }
             key.reset();
+        }
+        else {
+            LOGGER.debug("No commitLogFile is detected in cdc_raw directory.");
         }
     }
 

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
@@ -77,6 +77,7 @@ public class CommitLogProcessor extends AbstractProcessor {
 
     @Override
     public void process() throws IOException, InterruptedException {
+        LOGGER.debug("Processing commitLogFiles while initial is {}", initial);
         if (latestOnly) {
             processLastModifiedCommitLog();
             throw new InterruptedException();


### PR DESCRIPTION
Tested and verified that the PR fixes the following critical bug:
Cassandra Connector only processed the first commitLogFile flushed into cdc_raw after the connector gets started/restarted, and wasn't able to process the follow-up ones flushed in.

- Reset watch key every time after handling the polled events.
- Add more logs for debugging.