### PR TITLE
DBZ-1591 Add parallel snapshot

### DIFF
--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2OffsetContext.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2OffsetContext.java
@@ -93,6 +93,12 @@ public class Db2OffsetContext implements OffsetContext {
         return sourceInfo.struct();
     }
 
+    @Override
+    public OffsetContext getDataCollectionOffsetContext(DataCollectionId collectionId) {
+        // Concurrent snapshot not support so mutable copy not used
+        throw new UnsupportedOperationException();
+    }
+
     public TxLogPosition getChangePosition() {
         return TxLogPosition.valueOf(sourceInfo.getCommitLsn(), sourceInfo.getChangeLsn());
     }

--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2SnapshotChangeEventSource.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2SnapshotChangeEventSource.java
@@ -189,6 +189,11 @@ public class Db2SnapshotChangeEventSource extends RelationalSnapshotChangeEventS
         return Optional.of(String.format("SELECT * FROM %s.%s", tableId.schema(), tableId.table()));
     }
 
+    @Override
+    protected boolean supportsConcurrentSnapshot() {
+        return false;
+    }
+
     /**
      * Mutable context which is populated in the course of snapshotting.
      */

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -229,6 +229,18 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
     }
 
     @Override
+    protected void prepareSnapshotWorker(Statement statement, RelationalSnapshotContext snapshotContext) throws SQLException {
+        if (connectorConfig.getPdbName() != null) {
+            statement.execute("alter session set container=" + connectorConfig.getPdbName());
+        }
+    }
+
+    @Override
+    protected boolean supportsConcurrentSnapshot() {
+        return true;
+    }
+
+    @Override
     protected void complete(SnapshotContext snapshotContext) {
         if (connectorConfig.getPdbName() != null) {
             jdbcConnection.resetSessionToCdb();

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
@@ -8,6 +8,7 @@ package io.debezium.connector.oracle;
 import java.time.Instant;
 
 import io.debezium.annotation.NotThreadSafe;
+import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.common.BaseSourceInfo;
 import io.debezium.relational.TableId;
 
@@ -67,6 +68,11 @@ public class SourceInfo extends BaseSourceInfo {
 
     public void setTableId(TableId tableId) {
         this.tableId = tableId;
+    }
+
+    @Override
+    protected SnapshotRecord snapshot() {
+        return super.snapshot();
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1591

Adds support for performing snapshots concurrently to the postgres and oracle
connectors. The snapshot process is now performed using a fixed worker thread
pool whose size is controlled by the "snapshot.max.threads" property.
Worker threads open a new connection to the datasource to snapshot a single
datasource object(ex. table) and close when finished. Connectors that do
support concurrent snapshots is a special case where the existing connection
is reused, performed on a fixed single thread pool, and all snapshotted objects
are published in order.

Also see: https://github.com/debezium/debezium/pull/1450