### PR TITLE
DBZ-1985 More meaningful exception in case of non-existent commit log…

### DIFF
--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogUtil.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogUtil.java
@@ -69,6 +69,10 @@ public final class CommitLogUtil {
      * If the directory does not contain any commit logs, an empty array is returned.
      */
     public static File[] getCommitLogs(File directory) {
+        if (!directory.isDirectory()) {
+            throw new IllegalArgumentException("Given directory does not exist: " + directory);
+        }
+
         return directory.listFiles(f -> f.isFile() && FILENAME_REGEX_PATTERN.matcher(f.getName()).matches());
     }
 


### PR DESCRIPTION
… dir

https://issues.redhat.com/browse/DBZ-1985

Hey @bingqinzhou, so I had another look at the NPE. The only way that `getCommitLogs()` returns null (which in turn causes the NPE in `sort()`) is if the given directory doesn't exist. So I'm raising a more explicit exception in this case. Could you review and merge? // CC @criccomini @jgao54