### PR TITLE
DBZ-2066 Add more logs

### DIFF
--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
@@ -52,7 +52,9 @@ public class KafkaRecordEmitter implements AutoCloseable {
     public void emit(Record record) {
         synchronized (lock) {
             ProducerRecord<byte[], byte[]> producerRecord = toProducerRecord(record);
+            LOGGER.debug("Sending the record '{}'", record.toString());
             Future<RecordMetadata> future = producer.send(producerRecord);
+            LOGGER.debug("The record '{}' has been sent", record.toString());
             futures.put(record, future);
             maybeFlushAndMarkOffset();
         }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/SnapshotProcessor.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/SnapshotProcessor.java
@@ -155,6 +155,7 @@ public class SnapshotProcessor extends AbstractProcessor {
         LOGGER.info("Executing snapshot query '{}' with consistency level {}", statement.getQueryString(), statement.getConsistencyLevel());
         ResultSet resultSet = cassandraClient.execute(statement);
         processResultSet(tableMetadata, resultSet);
+        LOGGER.debug("The snapshot of table '{}' has been taken", tableName(tableMetadata));
     }
 
     /**


### PR DESCRIPTION
Add logs when the table snapshot is taken and when emitting a kafka message for a single record/mutation