### PR TITLE
[DBZ-2410] Improve error handling for Cassandra Connector

### DIFF
--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/BlackHoleCommitLogTransfer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/BlackHoleCommitLogTransfer.java
@@ -23,5 +23,6 @@ public class BlackHoleCommitLogTransfer implements CommitLogTransfer {
     }
 
     @Override
-    public void getErrorCommitLogFiles() {}
+    public void getErrorCommitLogFiles() {
+    }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/BlackHoleCommitLogTransfer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/BlackHoleCommitLogTransfer.java
@@ -23,5 +23,5 @@ public class BlackHoleCommitLogTransfer implements CommitLogTransfer {
     }
 
     @Override
-    public void getErrorCommitLogs() {}
+    public void getErrorCommitLogFiles() {}
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/BlackHoleCommitLogTransfer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/BlackHoleCommitLogTransfer.java
@@ -21,4 +21,7 @@ public class BlackHoleCommitLogTransfer implements CommitLogTransfer {
     public void onErrorTransfer(File file) {
         CommitLogUtil.deleteCommitLog(file);
     }
+
+    @Override
+    public void getErrorCommitLogs() {}
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -178,6 +178,13 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
             .withType(Type.BOOLEAN).withDefault(DEFAULT_COMMIT_LOG_POST_PROCESSING_ENABLED);
 
     /**
+     * Determine if CommitLogProcessor should re-process error commitLogFiles.
+     */
+    public static final boolean DEFAULT_COMMIT_LOG_ERROR_REPROCESSING_ENABLED = false;
+    public static final Field COMMIT_LOG_ERROR_REPROCESSING_ENABLED = Field.create("commit.log.error.reprocessing.enabled")
+            .withType(Type.BOOLEAN).withDefault(DEFAULT_COMMIT_LOG_ERROR_REPROCESSING_ENABLED);
+
+    /**
      * The fully qualified {@link CommitLogTransfer} class used to transfer commit logs.
      * The default option will delete all commit log files after processing (successful or otherwise).
      * You can extend a custom implementation.
@@ -343,6 +350,10 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
 
     public boolean postProcessEnabled() {
         return this.getConfig().getBoolean(COMMIT_LOG_POST_PROCESSING_ENABLED);
+    }
+
+    public boolean errorCommitLogReprocessEnabled() {
+        return this.getConfig().getBoolean(COMMIT_LOG_ERROR_REPROCESSING_ENABLED);
     }
 
     public CommitLogTransfer getCommitLogTransfer() {

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
@@ -125,10 +125,11 @@ public class CommitLogProcessor extends AbstractProcessor {
                 if (!latestOnly) {
                     queue.enqueue(new EOFEvent(file, false));
                 }
-                LOGGER.error("Error occurred while processing commit log " + file.getName(), e);
                 if (commitLogTransfer.getClass().getName().equals(CassandraConnectorConfig.DEFAULT_COMMIT_LOG_TRANSFER_CLASS)) {
+                    LOGGER.error("Error occurred while processing commit log " + file.getName(), e);
                     throw e;
                 }
+                LOGGER.warn("Error occurred while processing commit log " + file.getName(), e);
             }
         }
         catch (InterruptedException e) {

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
@@ -87,7 +87,7 @@ public class CommitLogProcessor extends AbstractProcessor {
             throw new InterruptedException();
         }
         if (errorCommitLogReprocessEnabled) {
-            commitLogTransfer.getErrorCommitLogs();
+            commitLogTransfer.getErrorCommitLogFiles();
         }
         if (initial) {
             LOGGER.info("Reading existing commit logs in {}", cdcDir);

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
@@ -125,8 +125,8 @@ public class CommitLogProcessor extends AbstractProcessor {
                 if (!latestOnly) {
                     queue.enqueue(new EOFEvent(file, false));
                 }
-                LOGGER.warn("Error occurred while processing commit log " + file.getName(), e);
-                if (commitLogTransfer.getClass().toString() == CassandraConnectorConfig.DEFAULT_COMMIT_LOG_TRANSFER_CLASS) {
+                LOGGER.error("Error occurred while processing commit log " + file.getName(), e);
+                if (commitLogTransfer.getClass().getName().equals(CassandraConnectorConfig.DEFAULT_COMMIT_LOG_TRANSFER_CLASS)) {
                     throw e;
                 }
             }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
@@ -126,6 +126,9 @@ public class CommitLogProcessor extends AbstractProcessor {
                     queue.enqueue(new EOFEvent(file, false));
                 }
                 LOGGER.warn("Error occurred while processing commit log " + file.getName(), e);
+                if (commitLogTransfer.getClass().toString() == CassandraConnectorConfig.DEFAULT_COMMIT_LOG_TRANSFER_CLASS) {
+                    throw e;
+                }
             }
         }
         catch (InterruptedException e) {

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogTransfer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogTransfer.java
@@ -39,5 +39,5 @@ public interface CommitLogTransfer {
     /**
      * Get all error commitLog files into cdc_raw directory for re-processing.
      */
-    void getErrorCommitLogs();
+    void getErrorCommitLogFiles();
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogTransfer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogTransfer.java
@@ -35,4 +35,9 @@ public interface CommitLogTransfer {
      * Transfer a commit log that has not been successfully processed.
      */
     void onErrorTransfer(File file);
+
+    /**
+     * Get all error commitLog files into cdc_raw directory for re-processing.
+     */
+    void getErrorCommitLogs();
 }

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
@@ -126,6 +126,10 @@ public class CassandraConnectorConfigTest {
         config = buildTaskConfig(CassandraConnectorConfig.COMMIT_LOG_POST_PROCESSING_ENABLED.name(), "false");
         assertEquals(false, config.postProcessEnabled());
 
+        boolean shouldReprocessErrorCommitLogs = true;
+        config = buildTaskConfig(CassandraConnectorConfig.COMMIT_LOG_ERROR_REPROCESSING_ENABLED.name(), shouldReprocessErrorCommitLogs);
+        assertEquals(shouldReprocessErrorCommitLogs, config.errorCommitLogReprocessEnabled());
+
         String transferClazz = "io.debezium.connector.cassandra.BlackHoleCommitLogTransfer";
         config = buildTaskConfig(CassandraConnectorConfig.COMMIT_LOG_TRANSFER_CLASS.name(), transferClazz);
         assertEquals(transferClazz, config.getCommitLogTransfer().getClass().getName());
@@ -170,6 +174,7 @@ public class CassandraConnectorConfigTest {
         assertEquals(CassandraConnectorConfig.DEFAULT_CDC_DIR_POLL_INTERVAL_MS, config.cdcDirPollIntervalMs().toMillis());
         assertEquals(CassandraConnectorConfig.DEFAULT_SNAPSHOT_POLL_INTERVAL_MS, config.snapshotPollIntervalMs().toMillis());
         assertEquals(CassandraConnectorConfig.DEFAULT_COMMIT_LOG_POST_PROCESSING_ENABLED, config.postProcessEnabled());
+        assertEquals(CassandraConnectorConfig.DEFAULT_COMMIT_LOG_ERROR_REPROCESSING_ENABLED, config.errorCommitLogReprocessEnabled());
         assertEquals(CassandraConnectorConfig.DEFAULT_COMMIT_LOG_TRANSFER_CLASS, config.getCommitLogTransfer().getClass().getName());
         assertFalse(config.cassandraSslEnabled());
         assertFalse(config.tombstonesOnDelete());

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
@@ -126,9 +126,8 @@ public class CassandraConnectorConfigTest {
         config = buildTaskConfig(CassandraConnectorConfig.COMMIT_LOG_POST_PROCESSING_ENABLED.name(), "false");
         assertEquals(false, config.postProcessEnabled());
 
-        boolean shouldReprocessErrorCommitLogs = true;
-        config = buildTaskConfig(CassandraConnectorConfig.COMMIT_LOG_ERROR_REPROCESSING_ENABLED.name(), shouldReprocessErrorCommitLogs);
-        assertEquals(shouldReprocessErrorCommitLogs, config.errorCommitLogReprocessEnabled());
+        config = buildTaskConfig(CassandraConnectorConfig.COMMIT_LOG_ERROR_REPROCESSING_ENABLED.name(), "true");
+        assertTrue(config.errorCommitLogReprocessEnabled());
 
         String transferClazz = "io.debezium.connector.cassandra.BlackHoleCommitLogTransfer";
         config = buildTaskConfig(CassandraConnectorConfig.COMMIT_LOG_TRANSFER_CLASS.name(), transferClazz);

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CommitLogPostProcessorTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CommitLogPostProcessorTest.java
@@ -37,7 +37,8 @@ public class CommitLogPostProcessorTest extends EmbeddedCassandraConnectorTestBa
             }
 
             @Override
-            public void getErrorCommitLogFiles() { }
+            public void getErrorCommitLogFiles() {
+            }
         };
         CassandraConnectorConfig config = spy(new CassandraConnectorConfig(Configuration.from(generateDefaultConfigMap())));
         when(config.getCommitLogTransfer()).thenReturn(myTransfer);

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CommitLogPostProcessorTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CommitLogPostProcessorTest.java
@@ -35,6 +35,9 @@ public class CommitLogPostProcessorTest extends EmbeddedCassandraConnectorTestBa
             public void onErrorTransfer(File file) {
                 errorFileCount.incrementAndGet();
             }
+
+            @Override
+            public void getErrorCommitLogFiles() { }
         };
         CassandraConnectorConfig config = spy(new CassandraConnectorConfig(Configuration.from(generateDefaultConfigMap())));
         when(config.getCommitLogTransfer()).thenReturn(myTransfer);


### PR DESCRIPTION
- Catch all exceptions when processing commitLogFiles instead of just IOException, if users use their self-implemented CommitLogTransfer class instead of the default BlackHoleCommitLogTransfer, Cassandra Connector doesn't need to stop for commitLog processing errors.
- Enable Cassandra Connector to re-process error commitLogFiles when related config is enabled.