### PR TITLE
DBZ-2462 avoid divisive languange in incubator connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,20 @@ Once connectors are deemed mature enough, they may be promoted into the Debezium
 
 Please see the [README.md](https://github.com/debezium/debezium#building-debezium) in the main repository for general instructions on building Debezium from source (prerequisites, usage of Docker etc).
 
-### Building the Cassandra connector
+### Building the Cassandra 3.x connector
 
-In order to build the Cassandra connector you'll need JDK <= 9 because Cassandra
-doesn't support Java versions above Java 9.
+In order to build the Cassandra connector you'll need JDK 8 because Cassandra 3.x
+doesn't support Java versions above Java 8. That also means dependencies like
+`debezium-core` have to be built as Java 8 bytecode version 52.0 as well,
+either by compiling it with Java 8 or specifying Java 8 bytecode generation
+on newer versions of Java.
 
 Then the Cassandra connector can be built like so:
 
     $ mvn clean install -am -pl debezium-connector-cassandra
     
-If you have multiple Java installation on your machine you can select the correct version by setting JAVA_HOME env var:
+If you have multiple Java installation on your machine you can select the correct
+version by setting JAVA_HOME env var:
 
     $ JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 mvn clean install -am -pl debezium-connector-cassandra
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ Once connectors are deemed mature enough, they may be promoted into the Debezium
 
 Please see the [README.md](https://github.com/debezium/debezium#building-debezium) in the main repository for general instructions on building Debezium from source (prerequisites, usage of Docker etc).
 
+### Building the Cassandra connector
+
+In order to build the Cassandra connector you'll need JDK <= 9 because Cassandra
+doesn't support Java versions above Java 9.
+
+Then the Cassandra connector can be built like so:
+
+    $ mvn clean install -am -pl debezium-connector-cassandra
+    
+If you have multiple Java installation on your machine you can select the correct version by setting JAVA_HOME env var:
+
+    $ JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 mvn clean install -am -pl debezium-connector-cassandra
+
 ### Building and testing the Db2 connector
 
 Running `mvn install` will compile all code and run the unit and integration tests. If there are any compile problems or any of the unit tests fail, the build will stop immediately. Otherwise, the command will continue to create the module's artifacts, create the Docker image with DB2 and custom scripts, start the Docker container, run the integration tests, stop the container (even if there are integration test failures), and run checkstyle on the code. If there are still no problems, the build will then install the module's artifacts into the local Maven repository.
@@ -69,10 +82,10 @@ making these parameters potentially obsolete.
 ```
 
 By default, Debezium will ignore some admin tables in Oracle 12c.
-But as those tables are different in Oracle 11g, Debezium will report an error on those tables. So when use Debezium on Oracle 11g, use table white list (remember to use lower case):
+But as those tables are different in Oracle 11g, Debezium will report an error on those tables. So when use Debezium on Oracle 11g, use `table.include.list` (remember to use lower case):
 
 ```json
-"table.whitelist":"orcl\\.debezium\\.(.*)"
+"table.include.list": "orcl\\.debezium\\.(.*)"
 ```
 
 Making this configuration obsolete is tracked under [DBZ-1045](https://issues.jboss.org/browse/DBZ-1045).

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -7,6 +7,8 @@ package io.debezium.connector.cassandra;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -249,7 +251,7 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)
             .withInvisibleRecommender()
-            .withDescription("Regular expressions matching columns to include in change events");
+            .withDescription("Regular expressions matching fields to include in change events");
 
     /**
      * Old, backwards-compatible "blacklist" property.
@@ -261,7 +263,7 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
             .withWidth(Width.LONG)
             .withImportance(Importance.LOW)
             .withInvisibleRecommender()
-            .withDescription("Regular expressions matching columns to include in change events (deprecated, use \"" + FIELD_EXCLUDE_LIST.name() + "\" instead)");
+            .withDescription("Regular expressions matching fields to include in change events (deprecated, use \"" + FIELD_EXCLUDE_LIST.name() + "\" instead)");
 
     /**
      * Instead of parsing commit logs from CDC directory, this will look for the commit log with the
@@ -433,12 +435,12 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
         return Duration.ofMillis(ms);
     }
 
-    public String[] fieldExcludeList() {
+    public List<String> fieldExcludeList() {
         String fieldExcludeList = this.getConfig().getFallbackStringProperty(FIELD_EXCLUDE_LIST, FIELD_BLACKLIST);
         if (fieldExcludeList == null) {
-            return new String[0];
+            return Collections.emptyList();
         }
-        return fieldExcludeList.split(",");
+        return Arrays.asList(fieldExcludeList.split(","));
     }
 
     /**

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
@@ -52,7 +52,7 @@ public class CommitLogProcessor extends AbstractProcessor {
                 context.getQueue(),
                 context.getOffsetWriter(),
                 new RecordMaker(context.getCassandraConnectorConfig().tombstonesOnDelete(),
-                        new Filters(context.getCassandraConnectorConfig().fieldBlacklist()),
+                        new Filters(context.getCassandraConnectorConfig().fieldExcludeList()),
                         context.getCassandraConnectorConfig()),
                 metrics);
         cdcDir = new File(DatabaseDescriptor.getCDCLogLocation());

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogUtil.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogUtil.java
@@ -53,7 +53,7 @@ public final class CommitLogUtil {
         try {
             Matcher filenameMatcher = FILENAME_REGEX_PATTERN.matcher(file.getName());
             if (!filenameMatcher.matches()) {
-                throw new IllegalArgumentException("Cannot delete file beca use " + file.getName() + " does not appear to be a CommitLog");
+                throw new IllegalArgumentException("Cannot delete file because " + file.getName() + " does not appear to be a CommitLog");
             }
 
             Files.delete(file.toPath());

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/FieldFilterSelector.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/FieldFilterSelector.java
@@ -12,10 +12,10 @@ import java.util.List;
  * This field filter selector is designed to determine the filter for excluding fields from a table.
  */
 public class FieldFilterSelector {
-    private final String[] blacklistFields;
+    private final String[] fieldExcludeList;
 
-    FieldFilterSelector(String[] blacklistFields) {
-        this.blacklistFields = blacklistFields.clone();
+    FieldFilterSelector(String[] fieldExcludeList) {
+        this.fieldExcludeList = fieldExcludeList.clone();
     }
 
     public interface FieldFilter {
@@ -27,7 +27,7 @@ public class FieldFilterSelector {
      */
     public FieldFilter selectFieldFilter(KeyspaceTable keyspaceTable) {
         List<Field> filteredFields = new ArrayList<>();
-        for (String column : blacklistFields) {
+        for (String column : fieldExcludeList) {
             Field field = new Field(column);
             if (field.keyspaceTable.equals(keyspaceTable)) {
                 filteredFields.add(field);
@@ -58,8 +58,8 @@ public class FieldFilterSelector {
         final KeyspaceTable keyspaceTable;
         final String column;
 
-        private Field(String fieldBlacklist) {
-            String[] elements = fieldBlacklist.split("\\.", 3);
+        private Field(String fieldExcludeList) {
+            String[] elements = fieldExcludeList.split("\\.", 3);
             String keyspace = elements[0];
             String table = elements[1];
             keyspaceTable = new KeyspaceTable(keyspace, table);

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/FieldFilterSelector.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/FieldFilterSelector.java
@@ -12,10 +12,10 @@ import java.util.List;
  * This field filter selector is designed to determine the filter for excluding fields from a table.
  */
 public class FieldFilterSelector {
-    private final String[] fieldExcludeList;
+    private final List<String> fieldExcludeList;
 
-    FieldFilterSelector(String[] fieldExcludeList) {
-        this.fieldExcludeList = fieldExcludeList.clone();
+    FieldFilterSelector(List<String> fieldExcludeList) {
+        this.fieldExcludeList = fieldExcludeList;
     }
 
     public interface FieldFilter {

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/Filters.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/Filters.java
@@ -7,14 +7,14 @@ package io.debezium.connector.cassandra;
 
 /**
  * A utility class that contains various kinds of filters.
- * Currently only field-level filter is implemented (i.e. blacklist).
+ * Currently only field-level filter is implemented (i.e. `field.exclude.list`).
  * Keyspace/table-level filters are not implemented.
  */
 public class Filters {
     private final FieldFilterSelector fieldFilterSelector;
 
-    public Filters(String[] fieldBlacklist) {
-        fieldFilterSelector = new FieldFilterSelector(fieldBlacklist);
+    public Filters(String[] fieldExcludeList) {
+        fieldFilterSelector = new FieldFilterSelector(fieldExcludeList);
     }
 
     /**

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/Filters.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/Filters.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.cassandra;
 
+import java.util.List;
+
 /**
  * A utility class that contains various kinds of filters.
  * Currently only field-level filter is implemented (i.e. `field.exclude.list`).
@@ -13,7 +15,7 @@ package io.debezium.connector.cassandra;
 public class Filters {
     private final FieldFilterSelector fieldFilterSelector;
 
-    public Filters(String[] fieldExcludeList) {
+    public Filters(List<String> fieldExcludeList) {
         fieldFilterSelector = new FieldFilterSelector(fieldExcludeList);
     }
 

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/SnapshotProcessor.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/SnapshotProcessor.java
@@ -71,7 +71,7 @@ public class SnapshotProcessor extends AbstractProcessor {
         offsetWriter = context.getOffsetWriter();
         schemaHolder = context.getSchemaHolder();
         recordMaker = new RecordMaker(context.getCassandraConnectorConfig().tombstonesOnDelete(),
-                new Filters(context.getCassandraConnectorConfig().fieldBlacklist()),
+                new Filters(context.getCassandraConnectorConfig().fieldExcludeList()),
                 context.getCassandraConnectorConfig());
         snapshotMode = context.getCassandraConnectorConfig().snapshotMode();
         consistencyLevel = context.getCassandraConnectorConfig().snapshotConsistencyLevel();

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
@@ -10,7 +10,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -110,11 +112,12 @@ public class CassandraConnectorConfigTest {
         assertEquals(snapshotPollIntervalMs, config.snapshotPollIntervalMs().toMillis());
 
         String fieldExcludeList = "keyspace1.table1.column1,keyspace1.table1.column2";
+        List<String> fieldExcludeListExpected = Arrays.asList(fieldExcludeList.split(","));
         config = buildTaskConfig(CassandraConnectorConfig.FIELD_EXCLUDE_LIST.name(), fieldExcludeList);
-        assertArrayEquals(fieldExcludeList.split(","), config.fieldExcludeList());
+        assertEquals(fieldExcludeListExpected, config.fieldExcludeList());
 
         config = buildTaskConfig(CassandraConnectorConfig.FIELD_BLACKLIST.name(), fieldExcludeList);
-        assertArrayEquals(fieldExcludeList.split(","), config.fieldExcludeList());
+        assertEquals(fieldExcludeListExpected, config.fieldExcludeList());
 
         config = buildTaskConfig(CassandraConnectorConfig.TOMBSTONES_ON_DELETE.name(), "true");
         assertTrue(config.tombstonesOnDelete());

--- a/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
+++ b/debezium-connector-cassandra/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
@@ -19,6 +19,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.debezium.config.Configuration;
 
 public class CassandraConnectorConfigTest {
+
     @Test
     public void testConfigs() {
         String connectorName = "test_connector";
@@ -108,9 +109,12 @@ public class CassandraConnectorConfigTest {
         config = buildTaskConfig(CassandraConnectorConfig.SNAPSHOT_POLL_INTERVAL_MS.name(), String.valueOf(snapshotPollIntervalMs));
         assertEquals(snapshotPollIntervalMs, config.snapshotPollIntervalMs().toMillis());
 
-        String fieldBlacklist = "keyspace1.table1.column1,keyspace1.table1.column2";
-        config = buildTaskConfig(CassandraConnectorConfig.FIELD_BLACKLIST.name(), fieldBlacklist);
-        assertArrayEquals(fieldBlacklist.split(","), config.fieldBlacklist());
+        String fieldExcludeList = "keyspace1.table1.column1,keyspace1.table1.column2";
+        config = buildTaskConfig(CassandraConnectorConfig.FIELD_EXCLUDE_LIST.name(), fieldExcludeList);
+        assertArrayEquals(fieldExcludeList.split(","), config.fieldExcludeList());
+
+        config = buildTaskConfig(CassandraConnectorConfig.FIELD_BLACKLIST.name(), fieldExcludeList);
+        assertArrayEquals(fieldExcludeList.split(","), config.fieldExcludeList());
 
         config = buildTaskConfig(CassandraConnectorConfig.TOMBSTONES_ON_DELETE.name(), "true");
         assertTrue(config.tombstonesOnDelete());
@@ -143,7 +147,6 @@ public class CassandraConnectorConfigTest {
         String valueConverterClass = "org.apache.kafka.connect.json.JsonConverter";
         config = buildTaskConfig(CassandraConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG.name(), valueConverterClass);
         assertEquals(valueConverterClass, config.getValueConverter().getClass().getName());
-
     }
 
     private CassandraConnectorConfig buildTaskConfigs(HashMap<String, Object> map) {

--- a/debezium-connector-cassandra/src/test/resources/cassandra-unit.yaml
+++ b/debezium-connector-cassandra/src/test/resources/cassandra-unit.yaml
@@ -45,7 +45,7 @@ num_tokens: 256
 # May either be "true" or "false" to enable globally
 hinted_handoff_enabled: true
 
-# When hinted_handoff_enabled is true, a black list of data centers that will not
+# When hinted_handoff_enabled is true, an exclude list of data centers that will not
 # perform hinted handoff
 # hinted_handoff_disabled_datacenters:
 #    - DC1

--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -279,17 +279,17 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
             SERVER_NAME,
             DATABASE_NAME,
             SNAPSHOT_MODE,
-            Db2ConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
-            Db2ConnectorConfig.DATABASE_HISTORY,
-            Db2ConnectorConfig.TABLE_WHITELIST,
-            Db2ConnectorConfig.TABLE_INCLUDE_LIST,
-            Db2ConnectorConfig.TABLE_BLACKLIST,
-            Db2ConnectorConfig.TABLE_EXCLUDE_LIST,
-            Db2ConnectorConfig.TABLE_IGNORE_BUILTIN,
-            Db2ConnectorConfig.COLUMN_BLACKLIST,
-            Db2ConnectorConfig.COLUMN_EXCLUDE_LIST,
-            Db2ConnectorConfig.DECIMAL_HANDLING_MODE,
-            Db2ConnectorConfig.TIME_PRECISION_MODE,
+            RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
+            HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY,
+            RelationalDatabaseConnectorConfig.TABLE_WHITELIST,
+            RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST,
+            RelationalDatabaseConnectorConfig.TABLE_BLACKLIST,
+            RelationalDatabaseConnectorConfig.TABLE_EXCLUDE_LIST,
+            RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN,
+            RelationalDatabaseConnectorConfig.COLUMN_BLACKLIST,
+            RelationalDatabaseConnectorConfig.COLUMN_EXCLUDE_LIST,
+            RelationalDatabaseConnectorConfig.DECIMAL_HANDLING_MODE,
+            RelationalDatabaseConnectorConfig.TIME_PRECISION_MODE,
             CommonConnectorConfig.POLL_INTERVAL_MS,
             CommonConnectorConfig.MAX_BATCH_SIZE,
             CommonConnectorConfig.MAX_QUEUE_SIZE,
@@ -305,21 +305,21 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         Field.group(config, "DB2 Server", HOSTNAME, PORT, USER, PASSWORD, SERVER_NAME, DATABASE_NAME, SNAPSHOT_MODE);
         Field.group(config, "History Storage", KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
                 KafkaDatabaseHistory.TOPIC, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
-                KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, Db2ConnectorConfig.DATABASE_HISTORY);
-        Field.group(config, "Events", Db2ConnectorConfig.TABLE_WHITELIST,
-                Db2ConnectorConfig.TABLE_INCLUDE_LIST,
-                Db2ConnectorConfig.TABLE_BLACKLIST,
-                Db2ConnectorConfig.TABLE_EXCLUDE_LIST,
-                Db2ConnectorConfig.COLUMN_BLACKLIST,
-                Db2ConnectorConfig.COLUMN_EXCLUDE_LIST,
-                Db2ConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
-                Db2ConnectorConfig.TABLE_IGNORE_BUILTIN,
+                KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY);
+        Field.group(config, "Events", RelationalDatabaseConnectorConfig.TABLE_WHITELIST,
+                RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST,
+                RelationalDatabaseConnectorConfig.TABLE_BLACKLIST,
+                RelationalDatabaseConnectorConfig.TABLE_EXCLUDE_LIST,
+                RelationalDatabaseConnectorConfig.COLUMN_BLACKLIST,
+                RelationalDatabaseConnectorConfig.COLUMN_EXCLUDE_LIST,
+                RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
+                RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN,
                 Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX,
                 CommonConnectorConfig.SOURCE_STRUCT_MAKER_VERSION,
                 CommonConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE);
         Field.group(config, "Connector", CommonConnectorConfig.POLL_INTERVAL_MS, CommonConnectorConfig.MAX_BATCH_SIZE,
                 CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.SNAPSHOT_DELAY_MS, CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
-                Db2ConnectorConfig.DECIMAL_HANDLING_MODE, Db2ConnectorConfig.TIME_PRECISION_MODE);
+                RelationalDatabaseConnectorConfig.DECIMAL_HANDLING_MODE, RelationalDatabaseConnectorConfig.TIME_PRECISION_MODE);
 
         return config;
     }
@@ -336,7 +336,7 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         this.snapshotMode = SnapshotMode.parse(config.getString(SNAPSHOT_MODE), SNAPSHOT_MODE.defaultValueAsString());
         this.snapshotIsolationMode = SnapshotIsolationMode.parse(config.getString(SNAPSHOT_ISOLATION_MODE), SNAPSHOT_ISOLATION_MODE.defaultValueAsString());
         this.columnFilter = getColumnNameFilter(
-                config.getFallbackStringProperty(Db2ConnectorConfig.COLUMN_EXCLUDE_LIST, Db2ConnectorConfig.COLUMN_BLACKLIST));
+                config.getFallbackStringProperty(RelationalDatabaseConnectorConfig.COLUMN_EXCLUDE_LIST, RelationalDatabaseConnectorConfig.COLUMN_BLACKLIST));
     }
 
     private static ColumnNameFilter getColumnNameFilter(String excludedColumnPatterns) {

--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ConnectorConfig.java
@@ -279,14 +279,17 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
             SERVER_NAME,
             DATABASE_NAME,
             SNAPSHOT_MODE,
-            RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
-            HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY,
-            RelationalDatabaseConnectorConfig.TABLE_WHITELIST,
-            RelationalDatabaseConnectorConfig.TABLE_BLACKLIST,
-            RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN,
-            RelationalDatabaseConnectorConfig.COLUMN_BLACKLIST,
-            RelationalDatabaseConnectorConfig.DECIMAL_HANDLING_MODE,
-            RelationalDatabaseConnectorConfig.TIME_PRECISION_MODE,
+            Db2ConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
+            Db2ConnectorConfig.DATABASE_HISTORY,
+            Db2ConnectorConfig.TABLE_WHITELIST,
+            Db2ConnectorConfig.TABLE_INCLUDE_LIST,
+            Db2ConnectorConfig.TABLE_BLACKLIST,
+            Db2ConnectorConfig.TABLE_EXCLUDE_LIST,
+            Db2ConnectorConfig.TABLE_IGNORE_BUILTIN,
+            Db2ConnectorConfig.COLUMN_BLACKLIST,
+            Db2ConnectorConfig.COLUMN_EXCLUDE_LIST,
+            Db2ConnectorConfig.DECIMAL_HANDLING_MODE,
+            Db2ConnectorConfig.TIME_PRECISION_MODE,
             CommonConnectorConfig.POLL_INTERVAL_MS,
             CommonConnectorConfig.MAX_BATCH_SIZE,
             CommonConnectorConfig.MAX_QUEUE_SIZE,
@@ -302,18 +305,21 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         Field.group(config, "DB2 Server", HOSTNAME, PORT, USER, PASSWORD, SERVER_NAME, DATABASE_NAME, SNAPSHOT_MODE);
         Field.group(config, "History Storage", KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
                 KafkaDatabaseHistory.TOPIC, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
-                KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY);
-        Field.group(config, "Events", RelationalDatabaseConnectorConfig.TABLE_WHITELIST,
-                RelationalDatabaseConnectorConfig.TABLE_BLACKLIST,
-                RelationalDatabaseConnectorConfig.COLUMN_BLACKLIST,
-                RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
-                RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN,
+                KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, Db2ConnectorConfig.DATABASE_HISTORY);
+        Field.group(config, "Events", Db2ConnectorConfig.TABLE_WHITELIST,
+                Db2ConnectorConfig.TABLE_INCLUDE_LIST,
+                Db2ConnectorConfig.TABLE_BLACKLIST,
+                Db2ConnectorConfig.TABLE_EXCLUDE_LIST,
+                Db2ConnectorConfig.COLUMN_BLACKLIST,
+                Db2ConnectorConfig.COLUMN_EXCLUDE_LIST,
+                Db2ConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
+                Db2ConnectorConfig.TABLE_IGNORE_BUILTIN,
                 Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX,
                 CommonConnectorConfig.SOURCE_STRUCT_MAKER_VERSION,
                 CommonConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE);
         Field.group(config, "Connector", CommonConnectorConfig.POLL_INTERVAL_MS, CommonConnectorConfig.MAX_BATCH_SIZE,
                 CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.SNAPSHOT_DELAY_MS, CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
-                RelationalDatabaseConnectorConfig.DECIMAL_HANDLING_MODE, RelationalDatabaseConnectorConfig.TIME_PRECISION_MODE);
+                Db2ConnectorConfig.DECIMAL_HANDLING_MODE, Db2ConnectorConfig.TIME_PRECISION_MODE);
 
         return config;
     }
@@ -329,7 +335,8 @@ public class Db2ConnectorConfig extends HistorizedRelationalDatabaseConnectorCon
         this.databaseName = config.getString(DATABASE_NAME);
         this.snapshotMode = SnapshotMode.parse(config.getString(SNAPSHOT_MODE), SNAPSHOT_MODE.defaultValueAsString());
         this.snapshotIsolationMode = SnapshotIsolationMode.parse(config.getString(SNAPSHOT_ISOLATION_MODE), SNAPSHOT_ISOLATION_MODE.defaultValueAsString());
-        this.columnFilter = getColumnNameFilter(config.getString(RelationalDatabaseConnectorConfig.COLUMN_BLACKLIST));
+        this.columnFilter = getColumnNameFilter(
+                config.getFallbackStringProperty(Db2ConnectorConfig.COLUMN_EXCLUDE_LIST, Db2ConnectorConfig.COLUMN_BLACKLIST));
     }
 
     private static ColumnNameFilter getColumnNameFilter(String excludedColumnPatterns) {

--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ConnectorTask.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ConnectorTask.java
@@ -26,7 +26,6 @@ import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
 import io.debezium.pipeline.spi.OffsetContext;
-import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.DatabaseHistory;
 import io.debezium.schema.TopicSelector;
@@ -70,7 +69,7 @@ public class Db2ConnectorTask extends BaseSourceTask {
                 .build();
 
         final Configuration jdbcConfig = config.filter(
-                x -> !(x.startsWith(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING) || x.equals(HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY.name())))
+                x -> !(x.startsWith(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING) || x.equals(Db2ConnectorConfig.DATABASE_HISTORY.name())))
                 .subset("database.", true);
         dataConnection = new Db2Connection(jdbcConfig);
         metadataConnection = new Db2Connection(jdbcConfig);

--- a/debezium-connector-db2/src/test/java/io/debezium/connector/db2/SchemaHistoryTopicIT.java
+++ b/debezium-connector-db2/src/test/java/io/debezium/connector/db2/SchemaHistoryTopicIT.java
@@ -22,7 +22,6 @@ import io.debezium.connector.db2.Db2ConnectorConfig.SnapshotMode;
 import io.debezium.connector.db2.util.TestHelper;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.AbstractConnectorTest;
-import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.util.Testing;
 
 /**
@@ -74,7 +73,7 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
         final int ID_START_1 = 10;
         final Configuration config = TestHelper.defaultConfig()
                 .with(Db2ConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
-                .with(RelationalDatabaseConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
+                .with(Db2ConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
                 .build();
 
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {

--- a/debezium-connector-db2/src/test/java/io/debezium/connector/db2/util/TestHelper.java
+++ b/debezium-connector-db2/src/test/java/io/debezium/connector/db2/util/TestHelper.java
@@ -27,7 +27,6 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.db2.Db2Connection;
 import io.debezium.connector.db2.Db2ConnectorConfig;
 import io.debezium.jdbc.JdbcConfiguration;
-import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.history.FileDatabaseHistory;
 import io.debezium.util.Clock;
 import io.debezium.util.Metronome;
@@ -99,10 +98,10 @@ public class TestHelper {
         jdbcConfiguration.forEach(
                 (field, value) -> builder.with(Db2ConnectorConfig.DATABASE_CONFIG_PREFIX + field, value));
 
-        return builder.with(RelationalDatabaseConnectorConfig.SERVER_NAME, "testdb")
+        return builder.with(Db2ConnectorConfig.SERVER_NAME, "testdb")
                 .with(Db2ConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)
                 .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
-                .with(RelationalDatabaseConnectorConfig.INCLUDE_SCHEMA_CHANGES, false);
+                .with(Db2ConnectorConfig.INCLUDE_SCHEMA_CHANGES, false);
     }
 
     public static Db2Connection adminConnection() {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -138,13 +138,13 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             PDB_NAME,
             XSTREAM_SERVER_NAME,
             SNAPSHOT_MODE,
-            OracleConnectorConfig.DATABASE_HISTORY,
-            OracleConnectorConfig.TABLE_WHITELIST,
-            OracleConnectorConfig.TABLE_INCLUDE_LIST,
-            OracleConnectorConfig.TABLE_BLACKLIST,
-            OracleConnectorConfig.TABLE_EXCLUDE_LIST,
-            OracleConnectorConfig.TABLE_IGNORE_BUILTIN,
-            OracleConnectorConfig.MSG_KEY_COLUMNS,
+            HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY,
+            RelationalDatabaseConnectorConfig.TABLE_WHITELIST,
+            RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST,
+            RelationalDatabaseConnectorConfig.TABLE_BLACKLIST,
+            RelationalDatabaseConnectorConfig.TABLE_EXCLUDE_LIST,
+            RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN,
+            RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS,
             CommonConnectorConfig.POLL_INTERVAL_MS,
             CommonConnectorConfig.MAX_BATCH_SIZE,
             CommonConnectorConfig.MAX_QUEUE_SIZE,
@@ -182,13 +182,13 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                 XSTREAM_SERVER_NAME, SNAPSHOT_MODE);
         Field.group(config, "History Storage", KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
                 KafkaDatabaseHistory.TOPIC, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
-                KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, OracleConnectorConfig.DATABASE_HISTORY);
-        Field.group(config, "Events", OracleConnectorConfig.TABLE_WHITELIST,
-                OracleConnectorConfig.TABLE_INCLUDE_LIST,
-                OracleConnectorConfig.TABLE_BLACKLIST,
-                OracleConnectorConfig.TABLE_EXCLUDE_LIST,
-                OracleConnectorConfig.MSG_KEY_COLUMNS,
-                OracleConnectorConfig.TABLE_IGNORE_BUILTIN,
+                KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY);
+        Field.group(config, "Events", RelationalDatabaseConnectorConfig.TABLE_WHITELIST,
+                RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST,
+                RelationalDatabaseConnectorConfig.TABLE_BLACKLIST,
+                RelationalDatabaseConnectorConfig.TABLE_EXCLUDE_LIST,
+                RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS,
+                RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN,
                 CommonConnectorConfig.PROVIDE_TRANSACTION_METADATA,
                 Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX,
                 CommonConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE);
@@ -305,7 +305,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         /**
          * Perform a snapshot of the schema but no data upon initial startup of a connector.
          *
-         * @deprecated to be removed in 1.1; use {@link #INITIAL_SCHEMA} instead.
+         * @deprecated to be removed in 1.1; use {@link #SCHEMA_ONLY} instead.
          */
         @Deprecated
         INITIAL_SCHEMA_ONLY("initial_schema_only", false),

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -138,11 +138,13 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             PDB_NAME,
             XSTREAM_SERVER_NAME,
             SNAPSHOT_MODE,
-            HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY,
-            RelationalDatabaseConnectorConfig.TABLE_WHITELIST,
-            RelationalDatabaseConnectorConfig.TABLE_BLACKLIST,
-            RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN,
-            RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS,
+            OracleConnectorConfig.DATABASE_HISTORY,
+            OracleConnectorConfig.TABLE_WHITELIST,
+            OracleConnectorConfig.TABLE_INCLUDE_LIST,
+            OracleConnectorConfig.TABLE_BLACKLIST,
+            OracleConnectorConfig.TABLE_EXCLUDE_LIST,
+            OracleConnectorConfig.TABLE_IGNORE_BUILTIN,
+            OracleConnectorConfig.MSG_KEY_COLUMNS,
             CommonConnectorConfig.POLL_INTERVAL_MS,
             CommonConnectorConfig.MAX_BATCH_SIZE,
             CommonConnectorConfig.MAX_QUEUE_SIZE,
@@ -180,11 +182,13 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                 XSTREAM_SERVER_NAME, SNAPSHOT_MODE);
         Field.group(config, "History Storage", KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
                 KafkaDatabaseHistory.TOPIC, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
-                KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY);
-        Field.group(config, "Events", RelationalDatabaseConnectorConfig.TABLE_WHITELIST,
-                RelationalDatabaseConnectorConfig.TABLE_BLACKLIST,
-                RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS,
-                RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN,
+                KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, OracleConnectorConfig.DATABASE_HISTORY);
+        Field.group(config, "Events", OracleConnectorConfig.TABLE_WHITELIST,
+                OracleConnectorConfig.TABLE_INCLUDE_LIST,
+                OracleConnectorConfig.TABLE_BLACKLIST,
+                OracleConnectorConfig.TABLE_EXCLUDE_LIST,
+                OracleConnectorConfig.MSG_KEY_COLUMNS,
+                OracleConnectorConfig.TABLE_IGNORE_BUILTIN,
                 CommonConnectorConfig.PROVIDE_TRANSACTION_METADATA,
                 Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX,
                 CommonConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE);
@@ -291,7 +295,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     /**
      * The set of predefined SnapshotMode options or aliases.
      */
-    public static enum SnapshotMode implements EnumeratedValue {
+    public enum SnapshotMode implements EnumeratedValue {
 
         /**
          * Perform a snapshot of data and schema upon initial startup of a connector.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/AlterTableParserListener.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/AlterTableParserListener.java
@@ -54,7 +54,7 @@ public class AlterTableParserListener extends BaseParserListener {
     @Override
     public void enterAlter_table(PlSqlParser.Alter_tableContext ctx) {
         TableId tableId = new TableId(catalogName, schemaName, getTableName(ctx.tableview_name()));
-        // todo filter non-whitelisted tables
+        // todo filter tables not in table.include.list
         tableEditor = parser.databaseTables().editTable(tableId);
         if (tableEditor == null) {
             throw new ParsingException(null, "Trying to alter table " + tableId.toString()

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorFilterIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorFilterIT.java
@@ -23,7 +23,6 @@ import io.debezium.connector.oracle.OracleConnectorConfig.SnapshotMode;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.VerifyRecord;
 import io.debezium.embedded.AbstractConnectorTest;
-import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.util.Testing;
 
 /**
@@ -59,7 +58,7 @@ public class OracleConnectorFilterIT extends AbstractConnectorTest {
         try {
             adminConnection.execute("DROP USER debezium2 CASCADE");
         }
-        catch (SQLException e) {
+        catch (SQLException ignored) {
         }
 
         adminConnection.execute(
@@ -69,30 +68,30 @@ public class OracleConnectorFilterIT extends AbstractConnectorTest {
                 "GRANT CREATE TABLE TO debezium2",
                 "GRANT CREATE SEQUENCE TO debezium2",
                 "ALTER USER debezium2 QUOTA 100M ON users",
-                "create table debezium2.table2 (id numeric(9,0) not null,name varchar2(1000),primary key (id))",
-                "create table debezium2.nopk (id numeric(9,0) not null)",
-                "GRANT ALL PRIVILEGES ON debezium2.table2 to debezium",
-                "GRANT SELECT ON debezium2.table2 to " + TestHelper.CONNECTOR_USER,
-                "GRANT SELECT ON debezium2.nopk to " + TestHelper.CONNECTOR_USER,
+                "CREATE TABLE debezium2.table2 (id NUMERIC(9,0) NOT NULL, name VARCHAR2(1000), PRIMARY KEY (id))",
+                "CREATE TABLE debezium2.nopk (id NUMERIC(9,0) NOT NULL)",
+                "GRANT ALL PRIVILEGES ON debezium2.table2 TO debezium",
+                "GRANT SELECT ON debezium2.table2 TO " + TestHelper.CONNECTOR_USER,
+                "GRANT SELECT ON debezium2.nopk TO " + TestHelper.CONNECTOR_USER,
                 "ALTER TABLE debezium2.table2 ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS");
-        String ddl = "create table debezium.table1 (" +
-                "  id numeric(9,0) not null, " +
-                "  name varchar2(1000), " +
-                "  primary key (id)" +
+        String ddl = "CREATE TABLE debezium.table1 (" +
+                "  id NUMERIC(9,0) NOT NULL, " +
+                "  name VARCHAR2(1000), " +
+                "  PRIMARY KEY (id)" +
                 ")";
 
         connection.execute(ddl);
-        connection.execute("GRANT SELECT ON debezium.table1 to " + TestHelper.CONNECTOR_USER);
+        connection.execute("GRANT SELECT ON debezium.table1 TO " + TestHelper.CONNECTOR_USER);
         connection.execute("ALTER TABLE debezium.table1 ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS");
 
-        ddl = "create table debezium.table2 (" +
-                "  id numeric(9,0) not null, " +
-                "  name varchar2(1000), " +
-                "  primary key (id)" +
+        ddl = "CREATE TABLE debezium.table2 (" +
+                "  id NUMERIC(9,0) NOT NULL, " +
+                "  name VARCHAR2(1000), " +
+                "  PRIMARY KEY (id)" +
                 ")";
 
         connection.execute(ddl);
-        connection.execute("GRANT SELECT ON debezium.table2 to  " + TestHelper.CONNECTOR_USER);
+        connection.execute("GRANT SELECT ON debezium.table2 TO  " + TestHelper.CONNECTOR_USER);
         connection.execute("ALTER TABLE debezium.table2 ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS");
 
         initializeConnectorTestFramework();
@@ -100,10 +99,10 @@ public class OracleConnectorFilterIT extends AbstractConnectorTest {
     }
 
     @Test
-    public void shouldApplyWhitelistConfiguration() throws Exception {
+    public void shouldApplyTableWhitelistConfiguration() throws Exception {
         Configuration config = TestHelper.defaultConfig()
                 .with(
-                        RelationalDatabaseConnectorConfig.TABLE_WHITELIST,
+                        OracleConnectorConfig.TABLE_WHITELIST,
                         "DEBEZIUM2\\.TABLE2,DEBEZIUM\\.TABLE1,DEBEZIUM\\.TABLE3")
                 .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_SCHEMA_ONLY)
                 .build();
@@ -117,14 +116,14 @@ public class OracleConnectorFilterIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO debezium.table2 VALUES (2, 'Text-2')");
         connection.execute("COMMIT");
 
-        String ddl = "create table debezium.table3 (" +
-                "  id numeric(9, 0) not null, " +
-                "  name varchar2(1000), " +
-                "  primary key (id)" +
+        String ddl = "CREATE TABLE debezium.table3 (" +
+                "  id NUMERIC(9, 0) NOT NULL, " +
+                "  name VARCHAR2(1000), " +
+                "  PRIMARY KEY (id)" +
                 ")";
 
         connection.execute(ddl);
-        connection.execute("GRANT SELECT ON debezium.table3 to c##xstrm");
+        connection.execute("GRANT SELECT ON debezium.table3 TO c##xstrm");
 
         connection.execute("INSERT INTO debezium.table3 VALUES (3, 'Text-3')");
         connection.execute("COMMIT");
@@ -152,10 +151,62 @@ public class OracleConnectorFilterIT extends AbstractConnectorTest {
     }
 
     @Test
-    public void shouldApplyBlacklistConfiguration() throws Exception {
+    public void shouldApplyTableIncludeListConfiguration() throws Exception {
         Configuration config = TestHelper.defaultConfig()
                 .with(
-                        RelationalDatabaseConnectorConfig.TABLE_BLACKLIST,
+                        OracleConnectorConfig.TABLE_INCLUDE_LIST,
+                        "DEBEZIUM2\\.TABLE2,DEBEZIUM\\.TABLE1,DEBEZIUM\\.TABLE3")
+                .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_SCHEMA_ONLY)
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        connection.execute("INSERT INTO debezium.table1 VALUES (1, 'Text-1')");
+        connection.execute("INSERT INTO debezium.table2 VALUES (2, 'Text-2')");
+        connection.execute("COMMIT");
+
+        String ddl = "CREATE TABLE debezium.table3 (" +
+                "  id NUMERIC(9, 0) NOT NULL, " +
+                "  name VARCHAR2(1000), " +
+                "  PRIMARY KEY (id)" +
+                ")";
+
+        connection.execute(ddl);
+        connection.execute("GRANT SELECT ON debezium.table3 TO c##xstrm");
+
+        connection.execute("INSERT INTO debezium.table3 VALUES (3, 'Text-3')");
+        connection.execute("COMMIT");
+
+        SourceRecords records = consumeRecordsByTopic(2);
+
+        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.DEBEZIUM.TABLE1");
+        assertThat(testTableRecords).hasSize(1);
+
+        VerifyRecord.isValidInsert(testTableRecords.get(0), "ID", 1);
+        Struct after = (Struct) ((Struct) testTableRecords.get(0).value()).get("after");
+        assertThat(after.get("ID")).isEqualTo(1);
+        assertThat(after.get("NAME")).isEqualTo("Text-1");
+
+        testTableRecords = records.recordsForTopic("server1.DEBEZIUM.TABLE2");
+        assertThat(testTableRecords).isNull();
+
+        testTableRecords = records.recordsForTopic("server1.DEBEZIUM.TABLE3");
+        assertThat(testTableRecords).hasSize(1);
+
+        VerifyRecord.isValidInsert(testTableRecords.get(0), "ID", 3);
+        after = (Struct) ((Struct) testTableRecords.get(0).value()).get("after");
+        assertThat(after.get("ID")).isEqualTo(3);
+        assertThat(after.get("NAME")).isEqualTo("Text-3");
+    }
+
+    @Test
+    public void shouldApplyTableBlacklistConfiguration() throws Exception {
+        Configuration config = TestHelper.defaultConfig()
+                .with(
+                        OracleConnectorConfig.TABLE_BLACKLIST,
                         "DEBEZIUM\\.TABLE2,DEBEZIUM\\.CUSTOMER.*")
                 .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_SCHEMA_ONLY)
                 .build();
@@ -169,14 +220,66 @@ public class OracleConnectorFilterIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO debezium.table2 VALUES (2, 'Text-2')");
         connection.execute("COMMIT");
 
-        String ddl = "create table debezium.table3 (" +
-                "  id numeric(9,0) not null, " +
-                "  name varchar2(1000), " +
-                "  primary key (id)" +
+        String ddl = "CREATE TABLE debezium.table3 (" +
+                "  id NUMERIC(9,0) NOT NULL, " +
+                "  name VARCHAR2(1000), " +
+                "  PRIMARY KEY (id)" +
                 ")";
 
         connection.execute(ddl);
-        connection.execute("GRANT SELECT ON debezium.table3 to  " + TestHelper.CONNECTOR_USER);
+        connection.execute("GRANT SELECT ON debezium.table3 TO  " + TestHelper.CONNECTOR_USER);
+
+        connection.execute("INSERT INTO debezium.table3 VALUES (3, 'Text-3')");
+        connection.execute("COMMIT");
+
+        SourceRecords records = consumeRecordsByTopic(2);
+
+        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.DEBEZIUM.TABLE1");
+        assertThat(testTableRecords).hasSize(1);
+
+        VerifyRecord.isValidInsert(testTableRecords.get(0), "ID", 1);
+        Struct after = (Struct) ((Struct) testTableRecords.get(0).value()).get("after");
+        assertThat(after.get("ID")).isEqualTo(1);
+        assertThat(after.get("NAME")).isEqualTo("Text-1");
+
+        testTableRecords = records.recordsForTopic("server1.DEBEZIUM.TABLE2");
+        assertThat(testTableRecords).isNull();
+
+        testTableRecords = records.recordsForTopic("server1.DEBEZIUM.TABLE3");
+        assertThat(testTableRecords).hasSize(1);
+
+        VerifyRecord.isValidInsert(testTableRecords.get(0), "ID", 3);
+        after = (Struct) ((Struct) testTableRecords.get(0).value()).get("after");
+        assertThat(after.get("ID")).isEqualTo(3);
+        assertThat(after.get("NAME")).isEqualTo("Text-3");
+    }
+
+    @Test
+    public void shouldApplyTableExcludeListConfiguration() throws Exception {
+        Configuration config = TestHelper.defaultConfig()
+                .with(
+                        OracleConnectorConfig.TABLE_EXCLUDE_LIST,
+                        "DEBEZIUM\\.TABLE2,DEBEZIUM\\.CUSTOMER.*")
+                .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_SCHEMA_ONLY)
+                .build();
+
+        start(OracleConnector.class, config);
+        assertConnectorIsRunning();
+
+        waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        connection.execute("INSERT INTO debezium.table1 VALUES (1, 'Text-1')");
+        connection.execute("INSERT INTO debezium.table2 VALUES (2, 'Text-2')");
+        connection.execute("COMMIT");
+
+        String ddl = "CREATE TABLE debezium.table3 (" +
+                "  id NUMERIC(9,0) NOT NULL, " +
+                "  name VARCHAR2(1000), " +
+                "  PRIMARY KEY (id)" +
+                ")";
+
+        connection.execute(ddl);
+        connection.execute("GRANT SELECT ON debezium.table3 TO  " + TestHelper.CONNECTOR_USER);
 
         connection.execute("INSERT INTO debezium.table3 VALUES (3, 'Text-3')");
         connection.execute("COMMIT");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -145,7 +145,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
         connection.execute("COMMIT");
 
         Configuration config = TestHelper.defaultConfig()
-                .with(RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.MY-TABLE")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.MY-TABLE")
                 .build();
 
         start(OracleConnector.class, config);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -36,7 +36,6 @@ import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.heartbeat.Heartbeat;
-import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.util.Testing;
 
 /**
@@ -183,7 +182,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
     @Test
     public void shouldTakeSnapshot() throws Exception {
         Configuration config = TestHelper.defaultConfig()
-                .with(RelationalDatabaseConnectorConfig.TABLE_WHITELIST, "DEBEZIUM\\.CUSTOMER")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
                 .build();
 
         int expectedRecordCount = 0;
@@ -232,7 +231,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
     @Test
     public void shouldContinueWithStreamingAfterSnapshot() throws Exception {
         Configuration config = TestHelper.defaultConfig()
-                .with(RelationalDatabaseConnectorConfig.TABLE_WHITELIST, "DEBEZIUM\\.CUSTOMER")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
                 .build();
 
         int expectedRecordCount = 0;
@@ -303,7 +302,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
     @FixFor("DBZ-1223")
     public void shouldStreamTransaction() throws Exception {
         Configuration config = TestHelper.defaultConfig()
-                .with(RelationalDatabaseConnectorConfig.TABLE_WHITELIST, "DEBEZIUM\\.CUSTOMER")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
                 .build();
 
         // Testing.Print.enable();
@@ -394,7 +393,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
     @Test
     public void shouldStreamAfterRestart() throws Exception {
         Configuration config = TestHelper.defaultConfig()
-                .with(RelationalDatabaseConnectorConfig.TABLE_WHITELIST, "DEBEZIUM\\.CUSTOMER")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
                 .build();
 
         // Testing.Print.enable();
@@ -434,7 +433,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
     @Test
     public void shouldStreamAfterRestartAfterSnapshot() throws Exception {
         Configuration config = TestHelper.defaultConfig()
-                .with(RelationalDatabaseConnectorConfig.TABLE_WHITELIST, "DEBEZIUM\\.CUSTOMER")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
                 .build();
 
         // Testing.Print.enable();
@@ -470,7 +469,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
     @Test
     public void shouldReadChangeStreamForExistingTable() throws Exception {
         Configuration config = TestHelper.defaultConfig()
-                .with(RelationalDatabaseConnectorConfig.TABLE_WHITELIST, "DEBEZIUM\\.CUSTOMER")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
                 .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
                 .build();
 
@@ -560,7 +559,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
     @FixFor("DBZ-835")
     public void deleteWithoutTombstone() throws Exception {
         Configuration config = TestHelper.defaultConfig()
-                .with(RelationalDatabaseConnectorConfig.TABLE_WHITELIST, "DEBEZIUM\\.CUSTOMER")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
                 .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
                 .with(OracleConnectorConfig.TOMBSTONES_ON_DELETE, false)
                 .build();
@@ -604,7 +603,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
         TestHelper.dropTable(connection, "debezium.customer2");
 
         Configuration config = TestHelper.defaultConfig()
-                .with(RelationalDatabaseConnectorConfig.TABLE_WHITELIST, "DEBEZIUM\\.CUSTOMER2")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER2")
                 .build();
 
         start(OracleConnector.class, config);
@@ -641,7 +640,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
 
     @Test
     @FixFor("DBZ-800")
-    public void shouldReceiveHeartbeatAlsoWhenChangingNonWhitelistedTable() throws Exception {
+    public void shouldReceiveHeartbeatAlsoWhenChangingTableIncludeListTables() throws Exception {
         TestHelper.dropTable(connection, "debezium.dbz800a");
         TestHelper.dropTable(connection, "debezium.dbz800b");
 
@@ -649,7 +648,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
         // received from Postgres
         Configuration config = TestHelper.defaultConfig()
                 .with(Heartbeat.HEARTBEAT_INTERVAL, "1")
-                .with(OracleConnectorConfig.TABLE_WHITELIST, "DEBEZIUM\\.DBZ800B")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ800B")
                 .build();
 
         start(OracleConnector.class, config);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SchemaHistoryTopicIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SchemaHistoryTopicIT.java
@@ -22,7 +22,6 @@ import io.debezium.connector.oracle.OracleConnectorConfig.SnapshotMode;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.AbstractConnectorTest;
-import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.util.Testing;
 
 /**
@@ -77,8 +76,8 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
         final int ID_START_1 = 10;
         final Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
-                .with(RelationalDatabaseConnectorConfig.TABLE_WHITELIST, "DEBEZIUM\\.TABLE[ABC]")
-                .with(RelationalDatabaseConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.TABLE[ABC]")
+                .with(OracleConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
                 .build();
 
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SnapshotDatatypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SnapshotDatatypesIT.java
@@ -56,10 +56,10 @@ public class SnapshotDatatypesIT extends AbstractOracleDatatypesTest {
 
     protected Builder connectorConfig() {
         return TestHelper.defaultConfig()
-                .with(OracleConnectorConfig.TABLE_WHITELIST, getTableWhitelist());
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, getTableIncludeList());
     }
 
-    private String getTableWhitelist() {
+    private String getTableIncludeList() {
         switch (name.getMethodName()) {
             case "stringTypes":
                 return "debezium.type_string";

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/StreamingDatatypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/StreamingDatatypesIT.java
@@ -41,12 +41,12 @@ public class StreamingDatatypesIT extends AbstractOracleDatatypesTest {
     }
 
     protected Builder connectorConfig() {
-        String whitelistedTables = getAllTables().stream()
+        String tableIncludeList = getAllTables().stream()
                 .map(t -> t.replaceAll("\\.", "\\\\."))
                 .collect(Collectors.joining(","));
 
         return TestHelper.defaultConfig()
-                .with(OracleConnectorConfig.TABLE_WHITELIST, whitelistedTables)
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, tableIncludeList)
                 .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY);
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/TransactionMetadataIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/TransactionMetadataIT.java
@@ -24,7 +24,6 @@ import io.debezium.connector.oracle.OracleConnectorConfig.SnapshotMode;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.VerifyRecord;
 import io.debezium.embedded.AbstractConnectorTest;
-import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.util.Collect;
 import io.debezium.util.Testing;
 
@@ -74,7 +73,7 @@ public class TransactionMetadataIT extends AbstractConnectorTest {
     @Test
     public void transactionMetadata() throws Exception {
         Configuration config = TestHelper.defaultConfig()
-                .with(RelationalDatabaseConnectorConfig.TABLE_WHITELIST, "DEBEZIUM\\.CUSTOMER")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
                 .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
                 .with(OracleConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
                 .build();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -16,7 +16,6 @@ import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnectionFactory;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.jdbc.JdbcConfiguration;
-import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.history.FileDatabaseHistory;
 import io.debezium.util.Testing;
 
@@ -68,12 +67,12 @@ public class TestHelper {
         jdbcConfiguration.forEach(
                 (field, value) -> builder.with(OracleConnectorConfig.DATABASE_CONFIG_PREFIX + field, value));
 
-        return builder.with(RelationalDatabaseConnectorConfig.SERVER_NAME, SERVER_NAME)
+        return builder.with(OracleConnectorConfig.SERVER_NAME, SERVER_NAME)
                 .with(OracleConnectorConfig.PDB_NAME, "ORCLPDB1")
                 .with(OracleConnectorConfig.XSTREAM_SERVER_NAME, "dbzxout")
                 .with(OracleConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)
                 .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
-                .with(RelationalDatabaseConnectorConfig.INCLUDE_SCHEMA_CHANGES, false);
+                .with(OracleConnectorConfig.INCLUDE_SCHEMA_CHANGES, false);
     }
 
     public static OracleConnection defaultConnection() {
@@ -181,10 +180,10 @@ public class TestHelper {
 
     public static void dropTable(OracleConnection connection, String table) {
         try {
-            connection.execute("drop table " + table);
+            connection.execute("DROP TABLE " + table);
         }
         catch (SQLException e) {
-            if (!e.getMessage().contains("table or view does not exist")) {
+            if (!e.getMessage().contains("ORA-00942") || 942 != e.getErrorCode()) {
                 throw new RuntimeException(e);
             }
         }


### PR DESCRIPTION
* add include/exclude list properties for cassandra, db2 and oracle incubator connectors
* deprecate whitelist/blacklist properties
* clean some code + minor housekeeping

fixes https://issues.redhat.com/browse/DBZ-2462