### PR TITLE
DBZ-2257 Lock Db2 Dockerfile version to 11.5.0.0a.

### DIFF
--- a/debezium-connector-db2/src/test/docker/db2-cdc-docker/Dockerfile
+++ b/debezium-connector-db2/src/test/docker/db2-cdc-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibmcom/db2
+FROM ibmcom/db2:11.5.0.0a
 
 MAINTAINER  Peter Urbanetz
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2257