### PR TITLE
[DBZ-2512]: Fix error with collection type of UUID

### DIFF
--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogReadHandlerImpl.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogReadHandlerImpl.java
@@ -236,8 +236,8 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
                 process(pu, offsetPosition, keyspaceTable);
             }
             catch (Exception e) {
-                throw new DebeziumException(String.format("Failed to process PartitionUpdate s% at s% for table s%",
-                        pu, offsetPosition, keyspaceTable), e);
+                throw new DebeziumException(String.format("Failed to process PartitionUpdate %s at %s for table %s.",
+                        pu.toString(), offsetPosition.toString(), keyspaceTable.name()), e);
             }
         }
 
@@ -253,10 +253,10 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
     @Override
     public boolean shouldSkipSegmentOnError(CommitLogReadException exception) throws IOException {
         if (exception.permissible) {
-            LOGGER.error("Encountered a permissible exception during log replay: {}", exception);
+            LOGGER.error("Encountered a permissible exception during log replay", exception);
         }
         else {
-            LOGGER.error("Encountered a non-permissible exception during log replay: {}", exception);
+            LOGGER.error("Encountered a non-permissible exception during log replay", exception);
         }
         return false;
     }
@@ -410,7 +410,7 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
             }
             catch (Exception e) {
                 throw new DebeziumException(String.format("Failed to populate Column %s with Type %s of Table %s in KeySpace %s.",
-                        cd.name.toString(), cd.type, cd.cfName, cd.ksName), e);
+                        cd.name.toString(), cd.type.toString(), cd.cfName, cd.ksName), e);
             }
         }
     }
@@ -425,7 +425,7 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
             }
             catch (Exception e) {
                 throw new DebeziumException(String.format("Failed to populate Column %s with Type %s of Table %s in KeySpace %s.",
-                        cd.name.toString(), cd.type, cd.cfName, cd.ksName), e);
+                        cd.name.toString(), cd.type.toString(), cd.cfName, cd.ksName), e);
             }
         }
     }
@@ -452,7 +452,7 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
                 }
                 catch (Exception e) {
                     throw new DebeziumException(String.format("Failed to populate Column %s with Type %s of Table %s in KeySpace %s.",
-                            cd.name.toString(), cd.type, cd.cfName, cd.ksName), e);
+                            cd.name.toString(), cd.type.toString(), cd.cfName, cd.ksName), e);
                 }
             }
 
@@ -494,7 +494,7 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
             }
             catch (Exception e) {
                 throw new DebeziumException(String.format("Failed to deserialize Column %s with Type %s in Table %s and KeySpace %s.",
-                        cs.name.toString(), cs.type, cs.cfName, cs.ksName), e);
+                        cs.name.toString(), cs.type.toString(), cs.cfName, cs.ksName), e);
             }
 
             // composite partition key
@@ -528,7 +528,7 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
                 }
                 catch (Exception e) {
                     throw new DebeziumException(String.format("Failed to deserialize Column %s with Type %s in Table %s and KeySpace %s",
-                            cs.name.toString(), cs.type, cs.cfName, cs.ksName), e);
+                            cs.name.toString(), cs.type.toString(), cs.cfName, cs.ksName), e);
                 }
                 byte b = keyBytes.get();
                 if (b != 0) {

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogReadHandlerImpl.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/CommitLogReadHandlerImpl.java
@@ -232,7 +232,13 @@ public class CommitLogReadHandlerImpl implements CommitLogReadHandler {
                 return;
             }
 
-            process(pu, offsetPosition, keyspaceTable);
+            try {
+                process(pu, offsetPosition, keyspaceTable);
+            }
+            catch (Exception e) {
+                throw new DebeziumException(String.format("Failed to process PartitionUpdate s% at s% for table s%",
+                        pu, offsetPosition, keyspaceTable), e);
+            }
         }
 
         metrics.onSuccess();

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/CassandraTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/CassandraTypeDeserializer.java
@@ -152,4 +152,13 @@ public final class CassandraTypeDeserializer {
         TypeDeserializer typeDeserializer = TYPE_MAP.get(abstractType.getClass());
         return typeDeserializer.getSchemaBuilder(abstractType);
     }
+
+    /**
+     * Get TypeDeserializer of AbstractType
+     * @param abstractType the {@link AbstractType} of a column in cassandra
+     * @return the TypeDeserializer of the AbstractType.
+     */
+    public static TypeDeserializer getTypeDeserializer(AbstractType<?> abstractType) {
+        return TYPE_MAP.get(abstractType.getClass());
+    }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/DurationTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/DurationTypeDeserializer.java
@@ -12,15 +12,12 @@ import org.apache.cassandra.db.marshal.AbstractType;
 
 import io.debezium.connector.cassandra.transforms.CassandraTypeKafkaSchemaBuilders;
 import io.debezium.time.NanoDuration;
+import org.apache.kafka.connect.data.SchemaBuilder;
 
-public class DurationTypeDeserializer extends BasicTypeDeserializer {
+public class DurationTypeDeserializer extends TypeDeserializer {
     /*
      * Cassandra Duration type is serialized into micro seconds in double.
      */
-
-    public DurationTypeDeserializer() {
-        super(CassandraTypeKafkaSchemaBuilders.DURATION_TYPE);
-    }
 
     @Override
     public Object deserialize(AbstractType<?> abstractType, ByteBuffer bb) {
@@ -29,5 +26,10 @@ public class DurationTypeDeserializer extends BasicTypeDeserializer {
         int days = duration.getDays();
         long nanoSec = duration.getNanoseconds();
         return NanoDuration.durationNanos(0, months, days, 0, 0, 0, nanoSec);
+    }
+
+    @Override
+    public SchemaBuilder getSchemaBuilder(AbstractType<?> abstractType) {
+        return CassandraTypeKafkaSchemaBuilders.DURATION_TYPE;
     }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/DurationTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/DurationTypeDeserializer.java
@@ -9,10 +9,10 @@ import java.nio.ByteBuffer;
 
 import org.apache.cassandra.cql3.Duration;
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.kafka.connect.data.SchemaBuilder;
 
 import io.debezium.connector.cassandra.transforms.CassandraTypeKafkaSchemaBuilders;
 import io.debezium.time.NanoDuration;
-import org.apache.kafka.connect.data.SchemaBuilder;
 
 public class DurationTypeDeserializer extends LogicalTypeDeserializer {
     /*

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/DurationTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/DurationTypeDeserializer.java
@@ -14,22 +14,28 @@ import io.debezium.connector.cassandra.transforms.CassandraTypeKafkaSchemaBuilde
 import io.debezium.time.NanoDuration;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
-public class DurationTypeDeserializer extends TypeDeserializer {
+public class DurationTypeDeserializer extends LogicalTypeDeserializer {
     /*
      * Cassandra Duration type is serialized into micro seconds in double.
      */
 
     @Override
     public Object deserialize(AbstractType<?> abstractType, ByteBuffer bb) {
-        Duration duration = (Duration) super.deserialize(abstractType, bb);
-        int months = duration.getMonths();
-        int days = duration.getDays();
-        long nanoSec = duration.getNanoseconds();
-        return NanoDuration.durationNanos(0, months, days, 0, 0, 0, nanoSec);
+        Object value = super.deserialize(abstractType, bb);
+        return convertDeserializedValue(abstractType, value);
     }
 
     @Override
     public SchemaBuilder getSchemaBuilder(AbstractType<?> abstractType) {
         return CassandraTypeKafkaSchemaBuilders.DURATION_TYPE;
+    }
+
+    @Override
+    public Object convertDeserializedValue(AbstractType<?> abstractType, Object value) {
+        Duration duration = (Duration) value;
+        int months = duration.getMonths();
+        int days = duration.getDays();
+        long nanoSec = duration.getNanoseconds();
+        return NanoDuration.durationNanos(0, months, days, 0, 0, 0, nanoSec);
     }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/InetAddressDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/InetAddressDeserializer.java
@@ -9,9 +9,9 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.kafka.connect.data.SchemaBuilder;
 
 import io.debezium.connector.cassandra.transforms.CassandraTypeKafkaSchemaBuilders;
-import org.apache.kafka.connect.data.SchemaBuilder;
 
 public class InetAddressDeserializer extends LogicalTypeDeserializer {
 

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/InetAddressDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/InetAddressDeserializer.java
@@ -13,16 +13,22 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import io.debezium.connector.cassandra.transforms.CassandraTypeKafkaSchemaBuilders;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
-public class InetAddressDeserializer extends TypeDeserializer {
+public class InetAddressDeserializer extends LogicalTypeDeserializer {
 
     @Override
     public Object deserialize(AbstractType<?> abstractType, ByteBuffer bb) {
-        InetAddress inetAddress = (InetAddress) super.deserialize(abstractType, bb);
-        return inetAddress.toString();
+        Object value = super.deserialize(abstractType, bb);
+        return convertDeserializedValue(abstractType, value);
     }
 
     @Override
     public SchemaBuilder getSchemaBuilder(AbstractType<?> abstractType) {
         return CassandraTypeKafkaSchemaBuilders.STRING_TYPE;
+    }
+
+    @Override
+    public Object convertDeserializedValue(AbstractType<?> abstractType, Object value) {
+        InetAddress inetAddress = (InetAddress) value;
+        return inetAddress.toString();
     }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/InetAddressDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/InetAddressDeserializer.java
@@ -11,16 +11,18 @@ import java.nio.ByteBuffer;
 import org.apache.cassandra.db.marshal.AbstractType;
 
 import io.debezium.connector.cassandra.transforms.CassandraTypeKafkaSchemaBuilders;
+import org.apache.kafka.connect.data.SchemaBuilder;
 
-public class InetAddressDeserializer extends BasicTypeDeserializer {
-
-    public InetAddressDeserializer() {
-        super(CassandraTypeKafkaSchemaBuilders.STRING_TYPE);
-    }
+public class InetAddressDeserializer extends TypeDeserializer {
 
     @Override
     public Object deserialize(AbstractType<?> abstractType, ByteBuffer bb) {
         InetAddress inetAddress = (InetAddress) super.deserialize(abstractType, bb);
         return inetAddress.toString();
+    }
+
+    @Override
+    public SchemaBuilder getSchemaBuilder(AbstractType<?> abstractType) {
+        return CassandraTypeKafkaSchemaBuilders.STRING_TYPE;
     }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/ListTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/ListTypeDeserializer.java
@@ -41,7 +41,7 @@ public class ListTypeDeserializer extends CollectionTypeDeserializer<ListType<?>
         AbstractType<?> elementsType = listType.getElementsType();
         List<Object> deserializedList = new ArrayList<>(bbList.size());
         for (ByteBuffer bb : bbList) {
-            deserializedList.add(super.deserialize(elementsType, bb));
+            deserializedList.add(CassandraTypeDeserializer.deserialize(elementsType, bb));
         }
         return Values.convertToList(getSchemaBuilder(listType).build(), deserializedList);
     }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/ListTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/ListTypeDeserializer.java
@@ -55,7 +55,7 @@ public class ListTypeDeserializer extends CollectionTypeDeserializer<ListType<?>
     private List<?> convertDeserializedElementsIfNecessary(AbstractType<?> abstractType, List<?> deserializedList) {
         AbstractType<?> elementsType = ((ListType<?>) abstractType).getElementsType();
         TypeDeserializer elementsTypeDeserializer = CassandraTypeDeserializer.getTypeDeserializer(elementsType);
-        if (LogicalTypeDeserializer.isParentOf(elementsTypeDeserializer)) {
+        if (elementsTypeDeserializer instanceof LogicalTypeDeserializer) {
             List<Object> convertedDeserializedList = new ArrayList<>();
             for (Object element : deserializedList) {
                 Object convertedElement = ((LogicalTypeDeserializer) elementsTypeDeserializer).convertDeserializedValue(elementsType, element);

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/ListTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/ListTypeDeserializer.java
@@ -35,15 +35,13 @@ public class ListTypeDeserializer extends CollectionTypeDeserializer<ListType<?>
     }
 
     @Override
-    public Object deserialize(ListType<?> collectionType, ComplexColumnData ccd) {
-        List<ByteBuffer> bbList = collectionType.serializedValues(ccd.iterator());
-        AbstractType<?> innerType = collectionType.getElementsType();
-
+    public Object deserialize(ListType<?> listType, ComplexColumnData ccd) {
+        List<ByteBuffer> bbList = listType.serializedValues(ccd.iterator());
+        AbstractType<?> elementsType = listType.getElementsType();
         List<Object> deserializedList = new ArrayList<>(bbList.size());
         for (ByteBuffer bb : bbList) {
-            deserializedList.add(super.deserialize(innerType, bb));
+            deserializedList.add(super.deserialize(elementsType, bb));
         }
-
-        return Values.convertToList(getSchemaBuilder(collectionType).build(), deserializedList);
+        return Values.convertToList(getSchemaBuilder(listType).build(), deserializedList);
     }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/LogicalTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/LogicalTypeDeserializer.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra.transforms.type.deserializer;
+
+import org.apache.cassandra.db.marshal.AbstractType;
+
+public abstract class LogicalTypeDeserializer extends TypeDeserializer {
+    public abstract Object convertDeserializedValue(AbstractType<?> abstractType, Object value);
+}

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/LogicalTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/LogicalTypeDeserializer.java
@@ -7,6 +7,9 @@ package io.debezium.connector.cassandra.transforms.type.deserializer;
 
 import org.apache.cassandra.db.marshal.AbstractType;
 
+/**
+ * For deserializing logical-type columns in Cassandra, like UUID, TIMEUUID, Duration, etc.
+ */
 public abstract class LogicalTypeDeserializer extends TypeDeserializer {
 
     /**
@@ -17,12 +20,4 @@ public abstract class LogicalTypeDeserializer extends TypeDeserializer {
      */
     public abstract Object convertDeserializedValue(AbstractType<?> abstractType, Object value);
 
-    /**
-     * Check if a TypeDeserializer extends from LogicalTypeDeserializer
-     * @param typeDeserializer TypeDeserializer
-     * @return true if the TypeDeserializer extends from LogicalTypeDeserializer
-     */
-    public static boolean isParentOf(TypeDeserializer typeDeserializer) {
-        return LogicalTypeDeserializer.class.isAssignableFrom(typeDeserializer.getClass());
-    }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/LogicalTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/LogicalTypeDeserializer.java
@@ -8,5 +8,21 @@ package io.debezium.connector.cassandra.transforms.type.deserializer;
 import org.apache.cassandra.db.marshal.AbstractType;
 
 public abstract class LogicalTypeDeserializer extends TypeDeserializer {
+
+    /**
+     * Convert the deserialized value from Cassandra to an object that fits kafka schema type
+     * @param abstractType the {@link AbstractType} of a column in cassandra
+     * @param value the deserialized value of a column in cassandra
+     * @return the object converted from deserialized value
+     */
     public abstract Object convertDeserializedValue(AbstractType<?> abstractType, Object value);
+
+    /**
+     * Check if a TypeDeserializer extends from LogicalTypeDeserializer
+     * @param typeDeserializer TypeDeserializer
+     * @return true if the TypeDeserializer extends from LogicalTypeDeserializer
+     */
+    public static boolean isParentOf(TypeDeserializer typeDeserializer) {
+        return LogicalTypeDeserializer.class.isAssignableFrom(typeDeserializer.getClass());
+    }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/MapTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/MapTypeDeserializer.java
@@ -48,7 +48,7 @@ public class MapTypeDeserializer extends CollectionTypeDeserializer<MapType<?, ?
         while (i < bbList.size()) {
             ByteBuffer kbb = bbList.get(i++);
             ByteBuffer vbb = bbList.get(i++);
-            deserializedMap.put(super.deserialize(keysType, kbb), super.deserialize(valuesType, vbb));
+            deserializedMap.put(CassandraTypeDeserializer.deserialize(keysType, kbb), CassandraTypeDeserializer.deserialize(valuesType, vbb));
         }
         return Values.convertToMap(getSchemaBuilder(mapType).build(), deserializedMap);
     }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/MapTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/MapTypeDeserializer.java
@@ -72,7 +72,7 @@ public class MapTypeDeserializer extends CollectionTypeDeserializer<MapType<?, ?
                 key = ((LogicalTypeDeserializer) keysTypeDeserializer).convertDeserializedValue(keysType, key);
             }
             Object value = entry.getValue();
-            if (LogicalTypeDeserializer.isParentOf(valuesTypeDeserializer)) {
+            if (valuesTypeDeserializer instanceof LogicalTypeDeserializer) {
                 value = ((LogicalTypeDeserializer) valuesTypeDeserializer).convertDeserializedValue(valuesType, value);
             }
             resultedMap.put(key, value);

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/MapTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/MapTypeDeserializer.java
@@ -40,14 +40,14 @@ public class MapTypeDeserializer extends CollectionTypeDeserializer<MapType<?, ?
     @Override
     public Object deserialize(MapType<?, ?> mapType, ComplexColumnData ccd) {
         List<ByteBuffer> bbList = mapType.serializedValues(ccd.iterator());
-        AbstractType<?> keyType = mapType.getKeysType();
-        AbstractType<?> valueType = mapType.getValuesType();
+        AbstractType<?> keysType = mapType.getKeysType();
+        AbstractType<?> valuesType = mapType.getValuesType();
         Map<Object, Object> deserializedMap = new HashMap<>();
         int i = 0;
         while (i < bbList.size()) {
             ByteBuffer kbb = bbList.get(i++);
             ByteBuffer vbb = bbList.get(i++);
-            deserializedMap.put(super.deserialize(keyType, kbb), super.deserialize(valueType, vbb));
+            deserializedMap.put(super.deserialize(keysType, kbb), super.deserialize(valuesType, vbb));
         }
         return Values.convertToMap(getSchemaBuilder(mapType).build(), deserializedMap);
     }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/MapTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/MapTypeDeserializer.java
@@ -68,7 +68,7 @@ public class MapTypeDeserializer extends CollectionTypeDeserializer<MapType<?, ?
         Map<Object, Object> resultedMap = new HashMap<>();
         for (Map.Entry entry : deserializedMap.entrySet()) {
             Object key = entry.getKey();
-            if (LogicalTypeDeserializer.isParentOf(keysTypeDeserializer)) {
+            if (keysTypeDeserializer instanceof LogicalTypeDeserializer) {
                 key = ((LogicalTypeDeserializer) keysTypeDeserializer).convertDeserializedValue(keysType, key);
             }
             Object value = entry.getValue();

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/MapTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/MapTypeDeserializer.java
@@ -38,11 +38,10 @@ public class MapTypeDeserializer extends CollectionTypeDeserializer<MapType<?, ?
     }
 
     @Override
-    public Object deserialize(MapType<?, ?> collectionType, ComplexColumnData ccd) {
-        List<ByteBuffer> bbList = collectionType.serializedValues(ccd.iterator());
-        AbstractType<?> keyType = collectionType.getKeysType();
-        AbstractType<?> valueType = collectionType.getValuesType();
-
+    public Object deserialize(MapType<?, ?> mapType, ComplexColumnData ccd) {
+        List<ByteBuffer> bbList = mapType.serializedValues(ccd.iterator());
+        AbstractType<?> keyType = mapType.getKeysType();
+        AbstractType<?> valueType = mapType.getValuesType();
         Map<Object, Object> deserializedMap = new HashMap<>();
         int i = 0;
         while (i < bbList.size()) {
@@ -50,7 +49,6 @@ public class MapTypeDeserializer extends CollectionTypeDeserializer<MapType<?, ?
             ByteBuffer vbb = bbList.get(i++);
             deserializedMap.put(super.deserialize(keyType, kbb), super.deserialize(valueType, vbb));
         }
-
-        return Values.convertToMap(getSchemaBuilder(collectionType).build(), deserializedMap);
+        return Values.convertToMap(getSchemaBuilder(mapType).build(), deserializedMap);
     }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/SetTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/SetTypeDeserializer.java
@@ -25,29 +25,27 @@ public class SetTypeDeserializer extends CollectionTypeDeserializer<SetType<?>> 
     @Override
     public Object deserialize(AbstractType<?> abstractType, ByteBuffer bb) {
         Set<?> deserializedSet = (Set<?>) super.deserialize(abstractType, bb);
-        List<?> deserializedList = (new ArrayList<>(deserializedSet));
+        List<?> deserializedList = new ArrayList<>(deserializedSet);
         return Values.convertToList(getSchemaBuilder(abstractType).build(), deserializedList);
     }
 
     @Override
     public SchemaBuilder getSchemaBuilder(AbstractType<?> abstractType) {
-        SetType<?> listType = (SetType<?>) abstractType;
-        AbstractType<?> elementsType = listType.getElementsType();
+        SetType<?> setType = (SetType<?>) abstractType;
+        AbstractType<?> elementsType = setType.getElementsType();
         Schema innerSchema = CassandraTypeDeserializer.getSchemaBuilder(elementsType).build();
         return SchemaBuilder.array(innerSchema).optional();
     }
 
     @Override
-    public Object deserialize(SetType<?> collectionType, ComplexColumnData ccd) {
-        List<ByteBuffer> bbList = collectionType.serializedValues(ccd.iterator());
-        AbstractType<?> innerType = collectionType.getElementsType();
-
+    public Object deserialize(SetType<?> setType, ComplexColumnData ccd) {
+        List<ByteBuffer> bbList = setType.serializedValues(ccd.iterator());
+        AbstractType<?> elementsType = setType.getElementsType();
         Set<Object> deserializedSet = new HashSet<>();
         for (ByteBuffer bb : bbList) {
-            deserializedSet.add(super.deserialize(innerType, bb));
+            deserializedSet.add(super.deserialize(elementsType, bb));
         }
-
         List<Object> deserializedList = new ArrayList<>(deserializedSet);
-        return Values.convertToList(getSchemaBuilder(collectionType).build(), deserializedList);
+        return Values.convertToList(getSchemaBuilder(setType).build(), deserializedList);
     }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/SetTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/SetTypeDeserializer.java
@@ -58,7 +58,7 @@ public class SetTypeDeserializer extends CollectionTypeDeserializer<SetType<?>> 
     private List<Object> convertDeserializedElementsIfNecessary(AbstractType<?> abstractType, Set<?> deserializedSet) {
         AbstractType<?> elementsType = ((SetType<?>) abstractType).getElementsType();
         TypeDeserializer elementsTypeDeserializer = CassandraTypeDeserializer.getTypeDeserializer(elementsType);
-        if (LogicalTypeDeserializer.isParentOf(elementsTypeDeserializer)) {
+        if (elementsTypeDeserializer instanceof LogicalTypeDeserializer) {
             List<Object> convertedDeserializedList = new ArrayList<>();
             for (Object element : deserializedSet) {
                 Object convertedValue = ((LogicalTypeDeserializer) elementsTypeDeserializer).convertDeserializedValue(elementsType, element);

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/SetTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/SetTypeDeserializer.java
@@ -43,7 +43,7 @@ public class SetTypeDeserializer extends CollectionTypeDeserializer<SetType<?>> 
         AbstractType<?> elementsType = setType.getElementsType();
         Set<Object> deserializedSet = new HashSet<>();
         for (ByteBuffer bb : bbList) {
-            deserializedSet.add(super.deserialize(elementsType, bb));
+            deserializedSet.add(CassandraTypeDeserializer.deserialize(elementsType, bb));
         }
         List<Object> deserializedList = new ArrayList<>(deserializedSet);
         return Values.convertToList(getSchemaBuilder(setType).build(), deserializedList);

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/TimeUUIDTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/TimeUUIDTypeDeserializer.java
@@ -15,17 +15,22 @@ import org.apache.kafka.connect.data.Values;
 
 import io.debezium.connector.cassandra.transforms.UuidUtil;
 
-public class TimeUUIDTypeDeserializer extends TypeDeserializer {
+public class TimeUUIDTypeDeserializer extends LogicalTypeDeserializer {
 
     @Override
     public Object deserialize(AbstractType<?> abstractType, ByteBuffer bb) {
         Object value = super.deserialize(abstractType, bb);
-        byte[] bytes = UuidUtil.asBytes((java.util.UUID) value);
-        return Values.convertToString(getSchemaBuilder(abstractType).build(), bytes);
+        return convertDeserializedValue(abstractType, value);
     }
 
     @Override
     public SchemaBuilder getSchemaBuilder(AbstractType<?> abstractType) {
         return UUID_TYPE;
+    }
+
+    @Override
+    public Object convertDeserializedValue(AbstractType<?> abstractType, Object value) {
+        byte[] bytes = UuidUtil.asBytes((java.util.UUID) value);
+        return Values.convertToString(getSchemaBuilder(abstractType).build(), bytes);
     }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/TimestampTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/TimestampTypeDeserializer.java
@@ -13,17 +13,22 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 
 import io.debezium.connector.cassandra.transforms.CassandraTypeKafkaSchemaBuilders;
 
-public class TimestampTypeDeserializer extends TypeDeserializer {
+public class TimestampTypeDeserializer extends LogicalTypeDeserializer {
 
     @Override
     public Object deserialize(AbstractType<?> abstractType, ByteBuffer bb) {
         Object value = super.deserialize(abstractType, bb);
-        Date date = (Date) value;
-        return date.getTime();
+        return convertDeserializedValue(abstractType, value);
     }
 
     @Override
     public SchemaBuilder getSchemaBuilder(AbstractType<?> abstractType) {
         return CassandraTypeKafkaSchemaBuilders.TIMESTAMP_MILLI_TYPE;
+    }
+
+    @Override
+    public Object convertDeserializedValue(AbstractType<?> abstractType, Object value) {
+        Date date = (Date) value;
+        return date.getTime();
     }
 }

--- a/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/UUIDTypeDeserializer.java
+++ b/debezium-connector-cassandra/src/main/java/io/debezium/connector/cassandra/transforms/type/deserializer/UUIDTypeDeserializer.java
@@ -15,17 +15,22 @@ import org.apache.kafka.connect.data.Values;
 
 import io.debezium.connector.cassandra.transforms.UuidUtil;
 
-public class UUIDTypeDeserializer extends TypeDeserializer {
+public class UUIDTypeDeserializer extends LogicalTypeDeserializer {
 
     @Override
     public Object deserialize(AbstractType<?> abstractType, ByteBuffer bb) {
         Object value = super.deserialize(abstractType, bb);
-        byte[] bytes = UuidUtil.asBytes((java.util.UUID) value);
-        return Values.convertToString(getSchemaBuilder(abstractType).build(), bytes);
+        return convertDeserializedValue(abstractType, value);
     }
 
     @Override
     public SchemaBuilder getSchemaBuilder(AbstractType<?> abstractType) {
         return UUID_TYPE;
+    }
+
+    @Override
+    public Object convertDeserializedValue(AbstractType<?> abstractType, Object value) {
+        byte[] bytes = UuidUtil.asBytes((java.util.UUID) value);
+        return Values.convertToString(getSchemaBuilder(abstractType).build(), bytes);
     }
 }


### PR DESCRIPTION
This PR is to fix the issue in https://issues.redhat.com/browse/DBZ-2512:

After deserializing UUID column from Cassandra, we need convert the deserialized UUID value to String in order to fit in Kafka Connect Schema which doesn't have a UUID type. We need to add the same step to convert each UUID element in deserialized Collection<UUID> column to String as well, otherwise we'll get error when sending out change event to kafka for Collection<UUID> columns.