### PR TITLE
DBZ-2591 take last processed lsn from topic rather than from db regis…

### DIFF
--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -164,10 +164,9 @@ public class Db2Connection extends JdbcConnection {
             queries[idx] = query;
             // If the table was added in the middle of queried buffer we need
             // to adjust from to the first LSN available
-            final Lsn fromLsn = changeTable.getStartLsn().compareTo(intervalFromLsn) > 0 ? changeTable.getStartLsn() : intervalFromLsn;
-            LOGGER.trace("Getting changes for table {} in range[{}, {}]", changeTable, fromLsn, intervalToLsn);
+            LOGGER.trace("Getting changes for table {} in range[{}, {}]", changeTable, intervalFromLsn, intervalToLsn);
             preparers[idx] = statement -> {
-                statement.setBytes(1, fromLsn.getBinary());
+                statement.setBytes(1, intervalFromLsn.getBinary());
                 statement.setBytes(2, intervalToLsn.getBinary());
 
             };


### PR DESCRIPTION
In case connector was not working for some time  - new changes were completed and registered in register table.
Connector starts and gets max lsn from register table. In this case changes were made during connector was down were skipped and only last(max) change was processed.
FIX: get max processed lsn from topic without comparing it with value in register table,
