### PR TITLE
DBZ-2607 Fix NullPointerException when getting all table ids

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -108,7 +108,7 @@ public class OracleConnection extends JdbcConnection {
     }
 
     protected Set<TableId> getAllTableIds(String catalogName, String schemaNamePattern, boolean isView) throws SQLException {
-
+        schemaNamePattern = schemaNamePattern == null ? "" : schemaNamePattern;
         String query = "select table_name, owner from all_tables where table_name NOT LIKE 'MDRT_%' AND table_name not LIKE 'MDXT_%' " +
                 " and owner like '%" + schemaNamePattern.toUpperCase() + "%'";
         if (isView) {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2607

A regression was introduced by the LogMiner implementation that required `database.schema` to also be used for XStream.  This PR fixes this regression and does not require this configuration option to be provided when using XStreams.