### PR TITLE
[DBZ-2008] Fix Guava Compatibility issue.

### DIFF
--- a/debezium-connector-cassandra/pom.xml
+++ b/debezium-connector-cassandra/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>jetty-servlet</artifactId>
             <version>9.4.12.v20180830</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
 
         <!-- Kafka Connect -->
         <dependency>


### PR DESCRIPTION
`cassandra-driver-corer` has a dependency of `guava 19.0`, which however is overwritten by `guava 18.0` introduced by `cassandra-all`. This PR forces cassandra connector to use `guava 19.0` instead of `guava 18.0`.