### PR TITLE
DBZ-2683 Support partition tables

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
@@ -129,6 +129,6 @@ class SqlUtils {
 
         StringJoiner tableNames = new StringJoiner(",");
         tables.forEach(table -> tableNames.add("'" + table + "'"));
-        return " AND table_name IN (" + tableNames + ") AND SEG_NAME IN (" + tableNames + ") ";
+        return " AND table_name IN (" + tableNames + ") ";
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2683

Partiioin tables' SEG_NAME is not 'TABLE_NAME', the 'SEG_NAME' condition rejected all partition table.