### PR TITLE
DBZ-2796 Support for lowercase table and schema names in Db2.

### DIFF
--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ChangeTable.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ChangeTable.java
@@ -13,7 +13,7 @@ import io.debezium.relational.TableId;
  * There is usually one change table for each source table. When the schema of the source table
  * is changed then two change tables could be present.
  *
- * @author Jiri Pechanec, Peter Urbanetz
+ * @author Jiri Pechanec, Peter Urbanetz, Luis Garcés-Erice
  *
  */
 public class Db2ChangeTable extends ChangeTable {
@@ -30,14 +30,24 @@ public class Db2ChangeTable extends ChangeTable {
      */
     private Lsn stopLsn;
 
+    /**
+     * The table in the CDC schema that captures changes, suitably quoted for Db2 
+     */
+    private String db2CaptureInstance;
+
     public Db2ChangeTable(TableId sourceTableId, String captureInstance, int changeTableObjectId, Lsn startLsn, Lsn stopLsn) {
         super(captureInstance, sourceTableId, resolveChangeTableId(sourceTableId, captureInstance), changeTableObjectId);
         this.startLsn = startLsn;
         this.stopLsn = stopLsn;
+        this.db2CaptureInstance = Db2ObjectNameQuoter.quoteNameIfNecessary(captureInstance);
     }
 
     public Db2ChangeTable(String captureInstance, int changeTableObjectId, Lsn startLsn, Lsn stopLsn) {
         this(null, captureInstance, changeTableObjectId, startLsn, stopLsn);
+    }
+
+    public String getCaptureInstance() {
+        return db2CaptureInstance;
     }
 
     public Lsn getStartLsn() {
@@ -60,6 +70,6 @@ public class Db2ChangeTable extends ChangeTable {
     }
 
     private static TableId resolveChangeTableId(TableId sourceTableId, String captureInstance) {
-        return sourceTableId != null ? new TableId(sourceTableId.catalog(), CDC_SCHEMA, captureInstance) : null;
+        return sourceTableId != null ? new TableId(sourceTableId.catalog(), CDC_SCHEMA, Db2ObjectNameQuoter.quoteNameIfNecessary(captureInstance)) : null;
     }
 }

--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -231,7 +231,7 @@ public class Db2Connection extends JdbcConnection {
     }
 
     private String cdcNameForTable(TableId tableId) {
-        return tableId.schema() + '_' + tableId.table();
+        return Db2ObjectNameQuoter.quoteNameIfNecessary(tableId.schema() + '_' + tableId.table());
     }
 
     public static class CdcEnabledTable {

--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ObjectNameQuoter.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2ObjectNameQuoter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2;
+
+/**
+ * By default, names in Db2 are upper case. Unless quoted, 
+ * any name in a SQL statement will interpreted as the equivalent upper case string.
+ * 
+ * @author Luis Garcés-Erice
+ */
+
+public class Db2ObjectNameQuoter {
+
+    /**
+     * This function quotes a table or schema name in Db2 if the name contains 
+     * at least one lower case character.
+     *
+     * @param name The name of the object.
+     * @return The name of object between quotes if it is not all upper-case.
+     */
+    public static String quoteNameIfNecessary(String name) {
+        String quotedNameIfNecessary = name;
+        for (Character c : name.toCharArray()) {
+            if (Character.isLowerCase(c)) {
+                quotedNameIfNecessary = "\"" + quotedNameIfNecessary + "\"";
+                break;
+            }
+        }
+        return quotedNameIfNecessary;
+    }
+
+}

--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2SnapshotChangeEventSource.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2SnapshotChangeEventSource.java
@@ -106,8 +106,8 @@ public class Db2SnapshotChangeEventSource extends RelationalSnapshotChangeEventS
                     }
 
                     LOGGER.info("Locking table {}", tableId);
-
-                    String query = String.format("SELECT * FROM %s.%s WHERE 0=1 WITH CS", tableId.schema(), tableId.table());
+                    String query = String.format("SELECT * FROM %s.%s WHERE 0=1 WITH CS", Db2ObjectNameQuoter.quoteNameIfNecessary(tableId.schema()),
+                            Db2ObjectNameQuoter.quoteNameIfNecessary(tableId.table()));
                     statement.executeQuery(query).close();
                 }
             }
@@ -193,7 +193,8 @@ public class Db2SnapshotChangeEventSource extends RelationalSnapshotChangeEventS
      */
     @Override
     protected Optional<String> getSnapshotSelect(RelationalSnapshotContext snapshotContext, TableId tableId) {
-        return Optional.of(String.format("SELECT * FROM %s.%s", tableId.schema(), tableId.table()));
+        return Optional.of(String.format("SELECT * FROM %s.%s", Db2ObjectNameQuoter.quoteNameIfNecessary(tableId.schema()),
+                Db2ObjectNameQuoter.quoteNameIfNecessary(tableId.table())));
     }
 
     /**

--- a/debezium-connector-db2/src/test/java/io/debezium/connector/db2/Db2CaseSensitiveObjectIT.java
+++ b/debezium-connector-db2/src/test/java/io/debezium/connector/db2/Db2CaseSensitiveObjectIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.db2.Db2ConnectorConfig.SnapshotMode;
+import io.debezium.connector.db2.util.TestHelper;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.util.Testing;
+
+/**
+ * Integration test for the Debezium DB2 connector testing support for mixed case schema and table.
+ *
+ * @author Luis Garcés-Erice
+ */
+public class Db2CaseSensitiveObjectIT extends AbstractConnectorTest {
+
+    private Db2Connection connection;
+
+    @Before
+    public void before() throws SQLException {
+        connection = TestHelper.testConnection();
+        connection.execute("DELETE FROM ASNCDC.IBMSNAP_REGISTER");
+        connection.execute(
+                "CREATE TABLE \"testSchema\".\"tablea\" (id int not null, cola varchar(30), primary key (id))",
+                "INSERT INTO \"testSchema\".\"tablea\" VALUES(1, 'a')");
+        TestHelper.enableTableCdc(connection, "testSchema", "tablea");
+        initializeConnectorTestFramework();
+        Testing.Files.delete(TestHelper.DB_HISTORY_PATH);
+        Testing.Print.enable();
+    }
+
+    @After
+    public void after() throws SQLException {
+        if (connection != null) {
+            TestHelper.disableDbCdc(connection);
+            TestHelper.disableTableCdc(connection, "testSchema", "tablea");
+            connection.execute("DROP TABLE \"testSchema\".\"tablea\"");
+            connection.execute("DELETE FROM ASNCDC.IBMSNAP_REGISTER");
+            connection.execute("DELETE FROM ASNCDC.IBMQREP_COLVERSION");
+            connection.execute("DELETE FROM ASNCDC.IBMQREP_TABVERSION");
+            connection.close();
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-2796")
+    public void testCaseSensitiveSchemaAndTable() throws Exception {
+        final int RECORDS_PER_TABLE = 5;
+        final int ID_START = 10;
+        final Configuration config = TestHelper.defaultConfig()
+                .with(Db2ConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .with(Db2ConnectorConfig.TABLE_INCLUDE_LIST, "testSchema.tablea")
+                .build();
+
+        start(Db2Connector.class, config);
+        assertConnectorIsRunning();
+
+        // Wait for snapshot completion
+        consumeRecordsByTopic(1);
+
+        TestHelper.enableDbCdc(connection);
+        connection.execute("UPDATE ASNCDC.IBMSNAP_REGISTER SET STATE = 'A' WHERE SOURCE_OWNER = 'testSchema'");
+        TestHelper.refreshAndWait(connection);
+
+        for (int i = 0; i < RECORDS_PER_TABLE; i++) {
+            final int id = ID_START + i;
+            connection.execute(
+                    "INSERT INTO \"testSchema\".\"tablea\" VALUES(" + id + ", 'a')");
+        }
+
+        TestHelper.refreshAndWait(connection);
+
+        final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE);
+        final List<SourceRecord> tableA = records.recordsForTopic("testdb.testSchema.tablea");
+        assertThat(tableA).hasSize(RECORDS_PER_TABLE);
+
+        stopConnector();
+    }
+}


### PR DESCRIPTION
Currently the Db2 connector only supports tables with names in uppercase. This is because all names in Db2 SQL statements are assumed to be uppercase, independently of the actual case. The case of the name is only considered when specified between quotes.

The SQL replication back-end for CDC supports table names in any case, so the connector should be able to deal with tables whatever case the tables are specified in the configuration.