### PR TITLE
DBZ-2859 Support TNS Names and full RAC connection strings

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
+import io.debezium.config.Field;
 import io.debezium.connector.oracle.OracleConnectorConfig.ConnectorAdapter;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.Column;
@@ -46,6 +47,11 @@ public class OracleConnection extends JdbcConnection {
      * Returned by column metadata in Oracle if no scale is set;
      */
     private static final int ORACLE_UNSET_SCALE = -127;
+
+    /**
+     * A field for the raw jdbc url. This field has no default value.
+     */
+    private static final Field URL = Field.create("url", "Raw JDBC url");
 
     public OracleConnection(Configuration config, Supplier<ClassLoader> classLoaderSupplier) {
         super(config, resolveConnectionFactory(config), classLoaderSupplier);
@@ -274,7 +280,10 @@ public class OracleConnection extends JdbcConnection {
     }
 
     private static ConnectionFactory resolveConnectionFactory(Configuration config) {
-        final String connectionUrl = ConnectorAdapter.parse(config.getString("connection.adapter")).getConnectionUrl();
+
+        final String connectionUrl = config.getString(URL) != null ? config.getString(URL)
+                : ConnectorAdapter.parse(config.getString("connection.adapter")).getConnectionUrl();
+
         return JdbcConnection.patternBasedFactory(connectionUrl);
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.util.TestHelper;
+
+public class OracleConnectorConfigTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OracleConnectorConfigTest.class);
+
+    @Test
+    public void validXtreamNoUrl() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                    .with(OracleConnectorConfig.SERVER_NAME, "myserver")
+                    .with(OracleConnectorConfig.HOSTNAME, "MyHostname")
+                    .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
+                    .with(OracleConnectorConfig.XSTREAM_SERVER_NAME, "myserver")
+                    .with(OracleConnectorConfig.USER, "debezium")
+                    .build());
+        assertTrue(connectorConfig.getConfig().validateAndRecord(connectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+    @Test
+    public void validLogminerNoUrl() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                    .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
+                    .with(OracleConnectorConfig.SERVER_NAME, "myserver")
+                    .with(OracleConnectorConfig.HOSTNAME, "MyHostname")
+                    .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
+                    .with(OracleConnectorConfig.SCHEMA_NAME, "myschema")
+                    .with(OracleConnectorConfig.USER, "debezium")
+                    .build());
+        assertTrue(connectorConfig.getConfig().validateAndRecord(connectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+    @Test
+    public void validXtreamWithUrl() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                    .with(OracleConnectorConfig.SERVER_NAME, "myserver")
+                    .with(OracleConnectorConfig.URL, "jdbc:oci:thin:@myserver/mydatabase")
+                    .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
+                    .with(OracleConnectorConfig.XSTREAM_SERVER_NAME, "myserver")
+                    .with(OracleConnectorConfig.USER, "debezium")
+                    .build());
+        assertTrue(connectorConfig.getConfig().validateAndRecord(connectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+    @Test
+    public void validLogminerWithUrl() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                    .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
+                    .with(OracleConnectorConfig.SERVER_NAME, "myserver")
+                    .with(OracleConnectorConfig.URL, "MyHostname")
+                    .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
+                    .with(OracleConnectorConfig.SCHEMA_NAME, "myschema")
+                    .with(OracleConnectorConfig.USER, "debezium")
+                    .build());
+        assertTrue(connectorConfig.getConfig().validateAndRecord(connectorConfig.ALL_FIELDS, LOGGER::error));
+    }   
+
+    @Test
+    public void validUrlTNS() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                    .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
+                    .with(OracleConnectorConfig.SERVER_NAME, "myserver")
+                    .with(OracleConnectorConfig.URL, "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=192.68.1.11)(PORT=1701))(ADDRESS=(PROTOCOL=TCP)(HOST=192.68.1.12)(PORT=1701))(ADDRESS=(PROTOCOL=TCP)(HOST=192.68.1.13)(PORT=1701))(LOAD_BALANCE = yes)(FAILOVER = on)(CONNECT_DATA =(SERVER = DEDICATED)(SERVICE_NAME = myserver.mydomain.com)(FAILOVER_MODE =(TYPE = SELECT)(METHOD = BASIC)(RETRIES = 3)(DELAY = 5))))")
+                    .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
+                    .with(OracleConnectorConfig.SCHEMA_NAME, "myschema")
+                    .with(OracleConnectorConfig.USER, "debezium")
+                    .build());
+        assertTrue(connectorConfig.getConfig().validateAndRecord(connectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+
+    @Test
+    public void invalidNoHostnameNoUri() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                    .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
+                    .with(OracleConnectorConfig.SERVER_NAME, "myserver")
+                    .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
+                    .with(OracleConnectorConfig.SCHEMA_NAME, "myschema")
+                    .with(OracleConnectorConfig.USER, "debezium")
+                    .build());
+        assertFalse(connectorConfig.getConfig().validateAndRecord(connectorConfig.ALL_FIELDS, LOGGER::error));
+    } 
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2859

This PR adds a new database.url configuration field that can be used to provide a raw JDBC url. Right now, we are limited by having to specify a hostname when defining the JDBC connection which can be very limiting when the company is using TNS names in their JDBC urls or RAC cluster connection urls. Here are some examples of those JDBC urls:

_"jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=<hostname>)(PORT=<port>))(CONNECT_DATA=(SERVICE_NAME=<servicename>)))"_

or 

_"jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS_LIST=(LOAD_BALANCE=OFF)(FAILOVER=ON)(ADDRESS=(PROTOCOL=TCP)(HOST=<hostname1>)(PORT=<port1>))(ADDRESS=(PROTOCOL=TCP)(HOST=<hostname2>)(PORT=<port2>)))(CONNECT_DATA=SERVICE_NAME=<servicename>)(SERVER=DEDICATED)))"_

among others.

I added some unit tests and hopefully make sense. I made database.url optional but when used then the user can't skip hostname.