### PR TITLE
DBZ-2711 Supplemental logging is required for entire database rather than per monitored table

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
@@ -120,7 +120,7 @@ public class SqlUtils {
     }
 
     static String supplementalLoggingCheckQuery() {
-        return String.format("SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_ALL FROM %s", DATABASE_VIEW);
+        return String.format("SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_MIN FROM %s", DATABASE_VIEW);
     }
 
     static String currentScnQuery() {


### PR DESCRIPTION
I've tested snapshotting and replication with only SUPPLEMENTAL_LOG_DATA_MIN enabled - all works same as with SUPPLEMENTAL_LOG_DATA_ALL.