### PR TITLE
DBZ-2518 Implement Scn as a domain type

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/HistoryRecorder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/HistoryRecorder.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.oracle.logminer;
 
-import java.math.BigDecimal;
 import java.sql.Timestamp;
 
 import io.debezium.common.annotation.Incubating;
@@ -37,7 +36,7 @@ public interface HistoryRecorder extends AutoCloseable {
      * @param csf the continuation sequence flag
      * @param redoSql the redo SQL that performed the operation
      */
-    void record(BigDecimal scn, String tableName, String segOwner, int operationCode, Timestamp changeTime,
+    void record(Scn scn, String tableName, String segOwner, int operationCode, Timestamp changeTime,
                 String transactionId, int csf, String redoSql);
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.oracle.logminer;
 
-import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -91,7 +90,7 @@ class LogMinerQueryResultProcessor {
                 return 0;
             }
 
-            BigDecimal scn = RowMapper.getScn(transactionalBufferMetrics, resultSet);
+            Scn scn = RowMapper.getScn(transactionalBufferMetrics, resultSet);
             String tableName = RowMapper.getTableName(transactionalBufferMetrics, resultSet);
             String segOwner = RowMapper.getSegOwner(transactionalBufferMetrics, resultSet);
             int operationCode = RowMapper.getOperationCode(transactionalBufferMetrics, resultSet);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -22,7 +22,6 @@ import static io.debezium.connector.oracle.logminer.LogMinerHelper.setNlsSession
 import static io.debezium.connector.oracle.logminer.LogMinerHelper.setRedoLogFilesForMining;
 import static io.debezium.connector.oracle.logminer.LogMinerHelper.startLogMining;
 
-import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -267,7 +266,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
     // TODO computing the largest scn in the buffer is a left-over from previous incarnations, remove it.
     // TODO We don't need to keep largestScn in the buffer at all. clean it
     private void updateStartScn() {
-        long nextStartScn = transactionalBuffer.getLargestScn().equals(BigDecimal.ZERO) ? endScn : transactionalBuffer.getLargestScn().longValue();
+        long nextStartScn = transactionalBuffer.getLargestScn().equals(Scn.ZERO) ? endScn : transactionalBuffer.getLargestScn().longValue();
         if (nextStartScn <= startScn) {
             // When system is idle, largest SCN may stay unchanged, move it forward then
             transactionalBuffer.resetLargestScn(endScn);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/NeverHistoryRecorder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/NeverHistoryRecorder.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.oracle.logminer;
 
-import java.math.BigDecimal;
 import java.sql.Timestamp;
 
 import io.debezium.jdbc.JdbcConfiguration;
@@ -21,7 +20,7 @@ public class NeverHistoryRecorder implements HistoryRecorder {
     }
 
     @Override
-    public void record(BigDecimal scn, String tableName, String segOwner, int operationCode, Timestamp changeTime,
+    public void record(Scn scn, String tableName, String segOwner, int operationCode, Timestamp changeTime,
                        String transactionId, int csf, String redoSql) {
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/RowMapper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/RowMapper.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.oracle.logminer;
 
-import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -113,13 +112,13 @@ public class RowMapper {
         }
     }
 
-    public static BigDecimal getScn(TransactionalBufferMetrics metrics, ResultSet rs) {
+    public static Scn getScn(TransactionalBufferMetrics metrics, ResultSet rs) {
         try {
-            return rs.getBigDecimal(SCN);
+            return new Scn(rs.getBigDecimal(SCN));
         }
         catch (SQLException e) {
             logError(metrics, e, "SCN");
-            return new BigDecimal(-1);
+            return Scn.INVALID;
         }
     }
 
@@ -150,7 +149,7 @@ public class RowMapper {
      * @return the redo SQL
      */
     public static String getSqlRedo(TransactionalBufferMetrics metrics, ResultSet rs, boolean isDml,
-                                    HistoryRecorder historyRecorder, BigDecimal scn, String tableName,
+                                    HistoryRecorder historyRecorder, Scn scn, String tableName,
                                     String segOwner, int operationCode, Timestamp changeTime, String txId) {
         int lobLimitCounter = 9; // todo : decide on approach ( XStream chunk option) and Lob limit
         StringBuilder result = new StringBuilder(4000);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/Scn.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/Scn.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Oracle System Change Number implementation
+ *
+ * @author Chris Cranford
+ */
+public class Scn implements Comparable<Scn> {
+
+    public static final Scn INVALID = new Scn(new BigDecimal(-1));
+    public static final Scn ZERO = new Scn(BigDecimal.ZERO);
+    public static final Scn ONE = new Scn(BigDecimal.ONE);
+
+    private BigDecimal scn;
+
+    public Scn(BigDecimal scn) {
+        assert scn.scale() == 0;
+        this.scn = scn;
+    }
+
+    public static Scn fromLong(Long value) {
+        return new Scn(new BigDecimal(value));
+    }
+
+    public long longValue() {
+        return scn.longValue();
+    }
+
+    public Scn add(Scn value) {
+        return new Scn(scn.add(value.scn));
+    }
+
+    @Override
+    public int compareTo(Scn o) {
+        return scn.compareTo(o.scn);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Scn scn1 = (Scn) o;
+        return Objects.equals(scn, scn1.scn);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scn);
+    }
+
+    @Override
+    public String toString() {
+        return scn != null ? scn.toString() : "null";
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/valueholder/LogMinerDmlEntry.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/valueholder/LogMinerDmlEntry.java
@@ -5,10 +5,10 @@
  */
 package io.debezium.connector.oracle.logminer.valueholder;
 
-import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.List;
 
+import io.debezium.connector.oracle.logminer.Scn;
 import io.debezium.data.Envelope;
 
 public interface LogMinerDmlEntry {
@@ -38,7 +38,7 @@ public interface LogMinerDmlEntry {
      * The actual SCN will be assigned after commit
      * @return it's value
      */
-    BigDecimal getScn();
+    Scn getScn();
 
     /**
      * @return transaction ID
@@ -64,7 +64,7 @@ public interface LogMinerDmlEntry {
      * sets scn obtained from a Log Miner entry
      * @param scn it's value
      */
-    void setScn(BigDecimal scn);
+    void setScn(Scn scn);
 
     /**
      * Sets table name

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/valueholder/LogMinerDmlEntryImpl.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/valueholder/LogMinerDmlEntryImpl.java
@@ -5,11 +5,11 @@
  */
 package io.debezium.connector.oracle.logminer.valueholder;
 
-import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Objects;
 
+import io.debezium.connector.oracle.logminer.Scn;
 import io.debezium.data.Envelope;
 
 /**
@@ -25,7 +25,7 @@ public class LogMinerDmlEntryImpl implements LogMinerDmlEntry {
     private String objectName;
     private Timestamp sourceTime;
     private String transactionId;
-    private BigDecimal scn;
+    private Scn scn;
 
     public LogMinerDmlEntryImpl(Envelope.Operation commandType, List<LogMinerColumnValue> newLmColumnValues, List<LogMinerColumnValue> oldLmColumnValues) {
         this.commandType = commandType;
@@ -89,12 +89,12 @@ public class LogMinerDmlEntryImpl implements LogMinerDmlEntry {
     }
 
     @Override
-    public BigDecimal getScn() {
+    public Scn getScn() {
         return scn;
     }
 
     @Override
-    public void setScn(BigDecimal scn) {
+    public void setScn(Scn scn) {
         this.scn = scn;
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/RowMapperTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/RowMapperTest.java
@@ -94,12 +94,12 @@ public class RowMapperTest {
     @Test
     public void testGetScn() throws SQLException {
         Mockito.when(rs.getBigDecimal(1)).thenReturn(new BigDecimal(1));
-        BigDecimal scn = RowMapper.getScn(metrics, rs);
-        assertThat(scn.equals(new BigDecimal(1))).isTrue();
+        Scn scn = RowMapper.getScn(metrics, rs);
+        assertThat(scn).isEqualTo(Scn.fromLong(1L));
         verify(rs).getBigDecimal(1);
         Mockito.when(rs.getBigDecimal(1)).thenThrow(SQLException.class);
         scn = RowMapper.getScn(metrics, rs);
-        assertThat(scn.equals(new BigDecimal(-1))).isTrue();
+        assertThat(scn).isEqualTo(Scn.INVALID);
         verify(rs, times(2)).getBigDecimal(1);
     }
 
@@ -119,14 +119,14 @@ public class RowMapperTest {
     public void testSqlRedo() throws SQLException {
         Mockito.when(rs.getInt(6)).thenReturn(0);
         Mockito.when(rs.getString(2)).thenReturn("short_sql");
-        String sql = RowMapper.getSqlRedo(metrics, rs, false, null, BigDecimal.ONE, "", "", 1, null, "");
+        String sql = RowMapper.getSqlRedo(metrics, rs, false, null, Scn.ONE, "", "", 1, null, "");
         assertThat(sql.equals("short_sql")).isTrue();
         verify(rs).getInt(6);
         verify(rs).getString(2);
 
         Mockito.when(rs.getInt(6)).thenReturn(1).thenReturn(0);
         Mockito.when(rs.getString(2)).thenReturn("long").thenReturn("_sql");
-        sql = RowMapper.getSqlRedo(metrics, rs, false, null, BigDecimal.ONE, "", "", 1, null, "");
+        sql = RowMapper.getSqlRedo(metrics, rs, false, null, Scn.ONE, "", "", 1, null, "");
         assertThat(sql.equals("long_sql")).isTrue();
         verify(rs, times(3)).getInt(6);
         verify(rs, times(3)).getString(2);
@@ -136,21 +136,21 @@ public class RowMapperTest {
         Arrays.fill(chars, 'a');
         Mockito.when(rs.getString(2)).thenReturn(new String(chars));
         Mockito.when(rs.getInt(6)).thenReturn(1);
-        sql = RowMapper.getSqlRedo(metrics, rs, false, null, BigDecimal.ONE, "", "", 1, null, "");
+        sql = RowMapper.getSqlRedo(metrics, rs, false, null, Scn.ONE, "", "", 1, null, "");
         assertThat(sql.length()).isEqualTo(40_000);
         verify(rs, times(13)).getInt(6);
         verify(rs, times(13)).getString(2);
 
         Mockito.when(rs.getInt(6)).thenReturn(0);
         Mockito.when(rs.getString(2)).thenReturn(null);
-        sql = RowMapper.getSqlRedo(metrics, rs, false, null, BigDecimal.ONE, "", "", 1, null, "");
+        sql = RowMapper.getSqlRedo(metrics, rs, false, null, Scn.ONE, "", "", 1, null, "");
         assertThat(sql).isNull();
         verify(rs, times(13)).getInt(6);
         verify(rs, times(14)).getString(2);
 
         Mockito.when(rs.getInt(6)).thenReturn(0);
         Mockito.when(rs.getString(2)).thenThrow(SQLException.class);
-        sql = RowMapper.getSqlRedo(metrics, rs, false, null, BigDecimal.ONE, "", "", 1, null, "");
+        sql = RowMapper.getSqlRedo(metrics, rs, false, null, Scn.ONE, "", "", 1, null, "");
         assertThat(sql.equals("")).isTrue();
         verify(rs, times(13)).getInt(6);
         verify(rs, times(15)).getString(2);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ValueHolderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ValueHolderTest.java
@@ -71,7 +71,7 @@ public class ValueHolderTest {
         dmlEntryExpected.setTransactionId("transaction_id");
         dmlEntryExpected.setObjectName(TABLE_NAME);
         dmlEntryExpected.setObjectOwner(SCHEMA_NAME);
-        dmlEntryExpected.setScn(BigDecimal.ONE);
+        dmlEntryExpected.setScn(Scn.ONE);
         dmlEntryExpected.setSourceTime(new Timestamp(1000));
 
         String createStatement = IoUtil.read(IoUtil.getResourceAsStream("ddl/create_small_table.sql", null, getClass(), null, null));
@@ -82,7 +82,7 @@ public class ValueHolderTest {
 
         assertThat(dmlEntryParsed.equals(dmlEntryExpected)).isTrue();
         assertThat(dmlEntryExpected.getCommandType() == Envelope.Operation.CREATE).isTrue();
-        assertThat(dmlEntryExpected.getScn().equals(BigDecimal.ONE)).isTrue();
+        assertThat(dmlEntryExpected.getScn().equals(Scn.ONE)).isTrue();
         assertThat(dmlEntryExpected.getSourceTime().equals(new Timestamp(1000))).isTrue();
         assertThat(dmlEntryExpected.getTransactionId().equals("transaction_id")).isTrue();
         assertThat(dmlEntryExpected.getObjectOwner().equals(SCHEMA_NAME)).isTrue();


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2518

This introduces a new domain type `Scn` for the Oracle Logminer implementation.  There are still some changes that could be done here that tie into [DBZ-2457](https://issues.redhat.com/browse/DBZ-2457) that could be paired with this change.