### PR TITLE
DBZ-2711 Implement relaxed supplemental logging requirements for Logminer

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -140,7 +140,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                 }
 
                 setNlsSessionParameters(jdbcConnection);
-                checkSupplementalLogging(jdbcConnection, connectorConfig.getPdbName());
+                checkSupplementalLogging(jdbcConnection, connectorConfig.getPdbName(), schema);
 
                 initializeRedoLogsForMining(connection, false, archiveLogRetention);
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
@@ -120,7 +120,7 @@ public class SqlUtils {
     }
 
     static String supplementalLoggingCheckQuery() {
-        return String.format("SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_ALL FROM %s", DATABASE_VIEW);
+        return String.format("SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_MIN FROM %s", DATABASE_VIEW);
     }
 
     static String currentScnQuery() {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
@@ -51,6 +51,7 @@ public class SqlUtils {
     private static final String ARCHIVED_LOG_VIEW = "V$ARCHIVED_LOG";
     private static final String ARCHIVE_DEST_STATUS_VIEW = "V$ARCHIVE_DEST_STATUS";
     private static final String LOGMNR_CONTENTS_VIEW = "V$LOGMNR_CONTENTS";
+    private static final String ALL_LOG_GROUPS = "ALL_LOG_GROUPS";
 
     // log miner statements
     static final String BUILD_DICTIONARY = "BEGIN DBMS_LOGMNR_D.BUILD (options => DBMS_LOGMNR_D.STORE_IN_REDO_LOGS); END;";
@@ -119,8 +120,16 @@ public class SqlUtils {
         return String.format("SELECT F.MEMBER FROM %s LOG, %s F  WHERE LOG.GROUP#=F.GROUP# AND LOG.STATUS='CURRENT'", LOG_VIEW, LOGFILE_VIEW);
     }
 
-    static String supplementalLoggingCheckQuery() {
+    static String databaseSupplementalLoggingAllCheckQuery() {
+        return String.format("SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_ALL FROM %s", DATABASE_VIEW);
+    }
+
+    static String databaseSupplementalLoggingMinCheckQuery() {
         return String.format("SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_MIN FROM %s", DATABASE_VIEW);
+    }
+
+    static String tableSupplementalLoggingCheckQuery(TableId tableId) {
+        return String.format("SELECT 'KEY', LOG_GROUP_TYPE FROM %s WHERE OWNER = '%s' AND TABLE_NAME = '%s'", ALL_LOG_GROUPS, tableId.schema(), tableId.table());
     }
 
     static String currentScnQuery() {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorFilterIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorFilterIT.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -110,6 +111,13 @@ public class OracleConnectorFilterIT extends AbstractConnectorTest {
 
         initializeConnectorTestFramework();
         Testing.Files.delete(TestHelper.DB_HISTORY_PATH);
+    }
+
+    @After
+    public void after() throws SQLException {
+        TestHelper.dropTable(adminConnection, "debezium2.table2");
+        TestHelper.dropTable(adminConnection, "debezium2.nopk");
+        adminConnection.execute("DROP USER debezium2");
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
@@ -63,6 +63,14 @@ public class SqlUtilsTest {
                 " OR (OPERATION_CODE IN (7,36)) ORDER BY SCN";
         assertThat(result).isEqualTo(expected);
 
+        result = SqlUtils.databaseSupplementalLoggingMinCheckQuery();
+        expected = "SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_MIN FROM V$DATABASE";
+        assertThat(result).isEqualTo(expected);
+
+        result = SqlUtils.tableSupplementalLoggingCheckQuery(new TableId(null, "s", "t"));
+        expected = "SELECT 'KEY', LOG_GROUP_TYPE FROM ALL_LOG_GROUPS WHERE OWNER = 's' AND TABLE_NAME = 't'";
+        assertThat(result).isEqualTo(expected);
+
         result = SqlUtils.startLogMinerStatement(10L, 20L, OracleConnectorConfig.LogMiningStrategy.ONLINE_CATALOG, true);
         expected = "BEGIN sys.dbms_logmnr.start_logmnr(startScn => '10', endScn => '20', " +
                 "OPTIONS => DBMS_LOGMNR.DICT_FROM_ONLINE_CATALOG  + DBMS_LOGMNR.CONTINUOUS_MINE  + DBMS_LOGMNR.NO_ROWID_IN_STMT);END;";
@@ -100,7 +108,7 @@ public class SqlUtilsTest {
         expected = "SELECT F.MEMBER FROM V$LOG LOG, V$LOGFILE F  WHERE LOG.GROUP#=F.GROUP# AND LOG.STATUS='CURRENT'";
         assertThat(result).isEqualTo(expected);
 
-        result = SqlUtils.supplementalLoggingCheckQuery();
+        result = SqlUtils.databaseSupplementalLoggingAllCheckQuery();
         expected = "SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_ALL FROM V$DATABASE";
         assertThat(result).isEqualTo(expected);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2711

This PR builds atop of PR #230 by not only expecting minimal database level supplemental logging but also adding a check to verify that tables which are monitored by Oracle specify all columns being logged to maintain consistency with old behavior.