### PR TITLE
DBZ-2855: Missing log file error when current SCN is very large

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
@@ -44,7 +44,7 @@ public class LogMinerHelper {
     private static final String TOTAL = "TOTAL";
     private final static Logger LOGGER = LoggerFactory.getLogger(LogMinerHelper.class);
 
-    public final static String MAX_SCN_S = "1844674407370955161";
+    public final static String MAX_SCN_S = "18446744073709551615";
     public final static BigInteger MAX_SCN_BI = new BigInteger(MAX_SCN_S);
 
     public enum DATATYPE {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.oracle.logminer;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.CallableStatement;
 import java.sql.Connection;
@@ -44,6 +43,9 @@ public class LogMinerHelper {
     private final static String UNKNOWN = "unknown";
     private static final String TOTAL = "TOTAL";
     private final static Logger LOGGER = LoggerFactory.getLogger(LogMinerHelper.class);
+
+    public final static String MAX_SCN_S = "1844674407370955161";
+    public final static BigInteger MAX_SCN_BI = new BigInteger(MAX_SCN_S);
 
     public enum DATATYPE {
         LONG,
@@ -462,8 +464,8 @@ public class LogMinerHelper {
 
         removeLogFilesFromMining(connection);
 
-        Map<String, Long> onlineLogFilesForMining = getOnlineLogFilesForOffsetScn(connection, lastProcessedScn);
-        Map<String, Long> archivedLogFilesForMining = getArchivedLogFilesForOffsetScn(connection, lastProcessedScn, archiveLogRetention);
+        Map<String, BigInteger> onlineLogFilesForMining = getOnlineLogFilesForOffsetScn(connection, lastProcessedScn);
+        Map<String, BigInteger> archivedLogFilesForMining = getArchivedLogFilesForOffsetScn(connection, lastProcessedScn, archiveLogRetention);
 
         if (onlineLogFilesForMining.size() + archivedLogFilesForMining.size() == 0) {
             throw new IllegalStateException("None of log files contains offset SCN: " + lastProcessedScn + ", re-snapshot is required.");
@@ -524,18 +526,21 @@ public class LogMinerHelper {
      * @return size
      */
     private static int getRedoLogGroupSize(Connection connection) throws SQLException {
-        return getMap(connection, SqlUtils.allOnlineLogsQuery(), "-1").size();
+        return getMap(connection, SqlUtils.allOnlineLogsQuery(), MAX_SCN_S).size();
     }
 
     /**
      * This method returns all online log files, starting from one which contains offset SCN and ending with one containing largest SCN
      * 18446744073709551615 on Ora 19c is the max value of the nextScn in the current redo todo replace all Long with BigInteger for SCN
      */
-    public static Map<String, Long> getOnlineLogFilesForOffsetScn(Connection connection, Long offsetScn) throws SQLException {
-        Map<String, String> redoLogFiles = getMap(connection, SqlUtils.allOnlineLogsQuery(), "-1");
+    public static Map<String, BigInteger> getOnlineLogFilesForOffsetScn(Connection connection, Long offsetScn) throws SQLException {
+
+        // TODO: Make offset a BigInteger and refactor upstream
+        BigInteger offsetScnBi = BigInteger.valueOf(offsetScn);
+        Map<String, String> redoLogFiles = getMap(connection, SqlUtils.allOnlineLogsQuery(), MAX_SCN_S);
         return redoLogFiles.entrySet().stream()
-                .filter(entry -> new BigInteger(entry.getValue()).longValue() > offsetScn || new BigInteger(entry.getValue()).longValue() == -1).collect(Collectors
-                        .toMap(Map.Entry::getKey, e -> new BigInteger(e.getValue()).longValue() == -1 ? Long.MAX_VALUE : new BigInteger(e.getValue()).longValue()));
+                .filter(entry -> new BigInteger(entry.getValue()).compareTo(offsetScnBi) >= 0 || new BigInteger(entry.getValue()).equals(MAX_SCN_BI)).collect(Collectors
+                        .toMap(Map.Entry::getKey, e -> new BigInteger(e.getValue()).equals(MAX_SCN_BI) ? MAX_SCN_BI : new BigInteger(e.getValue())));
     }
 
     /**
@@ -546,10 +551,10 @@ public class LogMinerHelper {
      * @return                Map of archived files
      * @throws SQLException   if something happens
      */
-    public static Map<String, Long> getArchivedLogFilesForOffsetScn(Connection connection, Long offsetScn, Duration archiveLogRetention) throws SQLException {
-        Map<String, String> redoLogFiles = getMap(connection, SqlUtils.archiveLogsQuery(offsetScn, archiveLogRetention), "-1");
+    public static Map<String, BigInteger> getArchivedLogFilesForOffsetScn(Connection connection, Long offsetScn, Duration archiveLogRetention) throws SQLException {
+        Map<String, String> redoLogFiles = getMap(connection, SqlUtils.archiveLogsQuery(offsetScn, archiveLogRetention), MAX_SCN_S);
         return redoLogFiles.entrySet().stream().collect(
-                Collectors.toMap(Map.Entry::getKey, e -> new BigDecimal(e.getValue()).longValue() == -1 ? Long.MAX_VALUE : new BigDecimal(e.getValue()).longValue()));
+                Collectors.toMap(Map.Entry::getKey, e -> new BigInteger(e.getValue()).equals(MAX_SCN_BI) ? MAX_SCN_BI : new BigInteger(e.getValue())));
     }
 
     /**

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperIT.java
@@ -8,6 +8,7 @@ package io.debezium.connector.oracle;
 import static org.fest.assertions.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -112,7 +113,7 @@ public class LogMinerHelperIT extends AbstractConnectorTest {
         // case 2: oldest scn = oldest in not cleared archive
         List<BigDecimal> oneDayArchivedNextScn = getOneDayArchivedLogNextScn(conn);
         long oldestArchivedScn = getOldestArchivedScn(oneDayArchivedNextScn);
-        Map<String, Long> archivedLogsForMining = LogMinerHelper.getArchivedLogFilesForOffsetScn(conn, oldestArchivedScn, Duration.ofHours(0L));
+        Map<String, BigInteger> archivedLogsForMining = LogMinerHelper.getArchivedLogFilesForOffsetScn(conn, oldestArchivedScn, Duration.ofHours(0L));
         assertThat(archivedLogsForMining.size() == (oneDayArchivedNextScn.size() - 1)).isTrue();
 
         archivedRedoFiles = LogMinerHelper.getMap(conn, SqlUtils.archiveLogsQuery(oldestArchivedScn - 1, Duration.ofHours(0L)), "-1");
@@ -126,8 +127,8 @@ public class LogMinerHelperIT extends AbstractConnectorTest {
         LogMinerHelper.setRedoLogFilesForMining(conn, oldestArchivedScn, Duration.ofHours(0L));
 
         // eliminate duplications
-        Map<String, Long> onlineLogFilesForMining = LogMinerHelper.getOnlineLogFilesForOffsetScn(conn, oldestArchivedScn);
-        Map<String, Long> archivedLogFilesForMining = LogMinerHelper.getArchivedLogFilesForOffsetScn(conn, oldestArchivedScn, Duration.ofHours(0L));
+        Map<String, BigInteger> onlineLogFilesForMining = LogMinerHelper.getOnlineLogFilesForOffsetScn(conn, oldestArchivedScn);
+        Map<String, BigInteger> archivedLogFilesForMining = LogMinerHelper.getArchivedLogFilesForOffsetScn(conn, oldestArchivedScn, Duration.ofHours(0L));
         List<String> archivedLogFiles = archivedLogFilesForMining.entrySet().stream()
                 .filter(e -> !onlineLogFilesForMining.values().contains(e.getValue())).map(Map.Entry::getKey).collect(Collectors.toList());
         int archivedLogFilesCount = archivedLogFiles.size();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.debezium.connector.oracle.logminer.LogMinerHelper;
+
+public class LogMinerHelperTest {
+
+    private Connection connection = Mockito.mock(Connection.class);
+    private int current;
+    private String[][] mockRows;
+
+    @Before
+    public void beforeEach() throws Exception {
+
+        current = 0;
+        mockRows = new String[][]{};
+
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        PreparedStatement pstmt = Mockito.mock(PreparedStatement.class);
+        Mockito.when(connection.prepareStatement(anyString())).thenReturn(pstmt);
+        Mockito.when(pstmt.executeQuery()).thenReturn(rs);
+        Mockito.when(rs.next()).thenAnswer(it -> ++current > mockRows.length ? false : true);
+        Mockito.when(rs.getString(anyInt())).thenAnswer(it -> {
+            return mockRows[current - 1][(Integer) it.getArguments()[0] - 1];
+        });
+    }
+
+    @Test
+    public void logsWithRegularScns() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" }
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getOnlineLogFilesForOffsetScn(connection, 10L);
+        assertEquals(onlineLogs.size(), 2);
+        assertEquals(onlineLogs.get("logfile1"), BigInteger.valueOf(103400L));
+        assertEquals(onlineLogs.get("logfile2"), BigInteger.valueOf(103700L));
+    }
+
+    @Test
+    public void excludeLogsBeforeOffsetScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", "500", "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getOnlineLogFilesForOffsetScn(connection, 600L);
+        assertEquals(onlineLogs.size(), 2);
+        assertNull(onlineLogs.get("logfile3"));
+    }
+
+    @Test
+    public void nullsHandledAsMaxScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", null, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getOnlineLogFilesForOffsetScn(connection, 600L);
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), LogMinerHelper.MAX_SCN_BI);
+    }
+
+    @Test
+    public void canHandleMaxScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", LogMinerHelper.MAX_SCN_S, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getOnlineLogFilesForOffsetScn(connection, 600L);
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), LogMinerHelper.MAX_SCN_BI);
+    }
+
+    @Test
+    public void logsWithLongerScnAreSupported() throws Exception {
+
+        // Proves that a SCN larger than what long data type supports, is still handled appropriately
+        String scnLonger = "9295429630892703743";
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", scnLonger, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getOnlineLogFilesForOffsetScn(connection, 600L);
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), new BigInteger(scnLonger));
+    }
+
+    @Test
+    public void archiveLogsWithRegularScns() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" }
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getArchivedLogFilesForOffsetScn(connection, 500L, Duration.ofDays(60));
+        assertEquals(onlineLogs.size(), 2);
+        assertEquals(onlineLogs.get("logfile1"), BigInteger.valueOf(103400L));
+        assertEquals(onlineLogs.get("logfile2"), BigInteger.valueOf(103700L));
+    }
+
+    // Following are the same set of tests used for online logs but on archived logs
+    @Test
+    @Ignore // TODO: Is this test not passing a bug?
+    public void archiveExcludeLogsBeforeOffsetScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", "500", "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getArchivedLogFilesForOffsetScn(connection, 600L, Duration.ofDays(60));
+        assertEquals(onlineLogs.size(), 2);
+        assertNull(onlineLogs.get("logfile3"));
+    }
+
+    @Test
+    public void archiveNullsHandledAsMaxScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", null, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getArchivedLogFilesForOffsetScn(connection, 500L, Duration.ofDays(60));
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), LogMinerHelper.MAX_SCN_BI);
+    }
+
+    @Test
+    public void archiveCanHandleMaxScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", LogMinerHelper.MAX_SCN_S, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getArchivedLogFilesForOffsetScn(connection, 500L, Duration.ofDays(60));
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), LogMinerHelper.MAX_SCN_BI);
+    }
+
+    @Test
+    public void archiveLogsWithLongerScnAreSupported() throws Exception {
+
+        // Proves that a SCN larger than what long data type supports, is still handled appropriately
+        String scnLonger = "9295429630892703743";
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", scnLonger, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getArchivedLogFilesForOffsetScn(connection, 500L, Duration.ofDays(60));
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), new BigInteger(scnLonger));
+    }
+}


### PR DESCRIPTION
This PR fixes a problem that happens when the NEXT_CHANGE# column in the [V$LOG](https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/V-LOG.html#GUID-FCD3B70B-7B98-40D8-98AB-9F6A85E69F57) view is longer than what the Long data type supports in Java which is a signed long whereas the Oracle value is an unsigned long. 

This PR uses BigInteger as an alternative approach to hold such large numbers. Alternatively, we could use the unsigned long support in Java 8 ( Long.parseUnsignedLong). I think that would be much better but I'm not aware of the backwards compatibility policy of this project so leaving that choice up to the team. 

Nevertheless, I believe some additional JIRA and PR work is needed to guarantee there are no other similar issues within the rest of the source code and migrate it to use BigInteger or unsigned longs where necessary.