### PR TITLE
DBZ-2981 Debezium swallows DML exception in certain cases

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/jsqlparser/SimpleDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/jsqlparser/SimpleDmlParser.java
@@ -133,7 +133,7 @@ public class SimpleDmlParser {
 
         }
         catch (Throwable e) {
-            LOGGER.error("Cannot parse statement : {}, transaction: {}, due to the {}", dmlContent, txId, e.getMessage());
+            LOGGER.error("Cannot parse statement : {}, transaction: {}, due to the {}", dmlContent, txId, e.getMessage(), e);
             return null;
         }
 


### PR DESCRIPTION
Very simple fix. SLF4J handles the last argument specially if it is an exception so that will get the stacktrace printed. This helps with exceptions like a NullPointerException as otherwise all we would get is a simple "null".