### PR TITLE
DBZ-2982 Allow to customize log mining properties

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -50,6 +50,17 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     public static final String DATABASE_CONFIG_PREFIX = "database.";
 
     protected static final int DEFAULT_PORT = 1528;
+    
+    protected static final int DEFAULT_VIEW_FETCH_SIZE = 10_000;
+
+    protected final static int DEFAULT_BATCH_SIZE = 20_000;
+    protected final static int MIN_BATCH_SIZE = 1_000;
+    protected final static int MAX_BATCH_SIZE = 100_000;
+
+    protected final static int MAX_SLEEP_TIME = 3_000;
+    protected final static int DEFAULT_SLEEP_TIME = 1_000;
+    protected final static int MIN_SLEEP_TIME = 0;
+    protected final static int SLEEP_TIME_INCREMENT = 200;
 
     public static final Field HOSTNAME = Field.create(DATABASE_CONFIG_PREFIX + JdbcConfiguration.HOSTNAME)
             .withDisplayName("Hostname")
@@ -222,6 +233,75 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withDefault(0)
             .withDescription("The number of hours in the past from SYSDATE to mine archive logs.  Using 0 mines all available archive logs");
 
+    public static final Field LOG_MINING_BATCH_SIZE_MIN = Field.create("log.mining.batch.size.min")
+            .withDisplayName("Minimum batch size for reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(MIN_BATCH_SIZE)
+            .withDescription(
+                    "The minimum SCN interval size that this connector will try to read from redo/archive logs. Active batch size will be also increased/decreased by this amount for tuning connector throughput when needed.");
+
+    public static final Field LOG_MINING_BATCH_SIZE_DEFAULT = Field.create("log.mining.batch.size.default")
+            .withDisplayName("Default batch size for reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(DEFAULT_BATCH_SIZE)
+            .withDescription("The starting SCN interval size that the connector will use for reading data from redo/archive logs.");
+
+    public static final Field LOG_MINING_BATCH_SIZE_MAX = Field.create("log.mining.batch.size.max")
+            .withDisplayName("Maximum batch size for reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(MAX_BATCH_SIZE)
+            .withDescription("The maximum SCN interval size that this connector will use when reading from redo/archive logs.");
+
+    public static final Field LOG_MINING_VIEW_FETCH_SIZE = Field.create("log.mining.view.fetch.size")
+            .withDisplayName("Number of content records that will be fetched.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(DEFAULT_VIEW_FETCH_SIZE)
+            .withDescription("The number of content records that will be fetched from the log miner content view.");
+
+    public static final Field LOG_MINING_SLEEP_TIME_MIN = Field.create("log.mining.sleep.time.min")
+            .withDisplayName("Minimum sleep time in milliseconds when reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(MIN_SLEEP_TIME)
+            .withDescription(
+                    "The minimum amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
+
+    public static final Field LOG_MINING_SLEEP_TIME_DEFAULT = Field.create("log.mining.sleep.time.default")
+            .withDisplayName("Default sleep time in milliseconds when reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(DEFAULT_SLEEP_TIME)
+            .withDescription(
+                    "The amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
+
+    public static final Field LOG_MINING_SLEEP_TIME_MAX = Field.create("log.mining.sleep.time.max")
+            .withDisplayName("Maximum sleep time in milliseconds when reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(MAX_SLEEP_TIME)
+            .withDescription(
+                    "The maximum amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
+
+    public static final Field LOG_MINING_SLEEP_TIME_INCREMENT = Field.create("log.mining.sleep.time.increment")
+            .withDisplayName("The increment in sleep time in milliseconds used to tune auto-sleep behavior.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(SLEEP_TIME_INCREMENT)
+            .withDescription(
+                    "The maximum amount of time that the connector will use to tune the optimal sleep time when reading data from logminer. Value is in milliseconds.");
+
     /**
      * The set of {@link Field}s defined as part of this configuration.
      */
@@ -262,7 +342,14 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             RAC_NODES,
             CommonConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE,
             URL,
-            LOG_MINING_ARCHIVE_LOG_HOURS);
+            LOG_MINING_ARCHIVE_LOG_HOURS,
+            LOG_MINING_BATCH_SIZE_DEFAULT,
+            LOG_MINING_BATCH_SIZE_MIN,
+            LOG_MINING_BATCH_SIZE_MAX,
+            LOG_MINING_SLEEP_TIME_DEFAULT,
+            LOG_MINING_SLEEP_TIME_MIN,
+            LOG_MINING_SLEEP_TIME_MAX,
+            LOG_MINING_SLEEP_TIME_INCREMENT);
 
     private final String databaseName;
     private final String pdbName;
@@ -335,7 +422,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         Field.group(config, "Connector", CommonConnectorConfig.POLL_INTERVAL_MS, CommonConnectorConfig.MAX_BATCH_SIZE,
                 CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.SNAPSHOT_DELAY_MS, CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
                 SNAPSHOT_ENHANCEMENT_TOKEN, LOG_MINING_HISTORY_RECORDER_CLASS, LOG_MINING_HISTORY_RETENTION, RAC_SYSTEM, RAC_NODES,
-                LOG_MINING_ARCHIVE_LOG_HOURS);
+                LOG_MINING_ARCHIVE_LOG_HOURS, LOG_MINING_BATCH_SIZE_DEFAULT, LOG_MINING_BATCH_SIZE_MIN, LOG_MINING_BATCH_SIZE_MAX,
+                LOG_MINING_SLEEP_TIME_DEFAULT, LOG_MINING_SLEEP_TIME_MIN, LOG_MINING_SLEEP_TIME_MAX, LOG_MINING_SLEEP_TIME_INCREMENT);
 
         return config;
     }
@@ -713,6 +801,70 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
      */
     public Duration getLogMiningArchiveLogRetention() {
         return Duration.ofHours(getConfig().getLong(LOG_MINING_ARCHIVE_LOG_HOURS));
+    }
+
+    /**
+     * 
+     * @return int The minimum SCN interval used when mining redo/archive logs
+     */
+    public int getLogMiningBatchSizeMin() {
+        return getConfig().getInteger(LOG_MINING_BATCH_SIZE_MIN);
+    }
+
+    /**
+     * 
+     * @return int Number of actual records that will be fetched from the log mining contents view
+     */
+    public int getLogMiningViewFetchSize() {
+        return getConfig().getInteger(LOG_MINING_VIEW_FETCH_SIZE);
+    }
+
+    /**
+     * 
+     * @return int The maximum SCN interval used when mining redo/archive logs
+     */
+    public int getLogMiningBatchSizeMax() {
+        return getConfig().getInteger(LOG_MINING_BATCH_SIZE_MAX);
+    }
+
+    /**
+     * 
+     * @return int The default SCN interval used when mining redo/archive logs
+     */
+    public int getLogMiningBatchSizeDefault() {
+        return getConfig().getInteger(LOG_MINING_BATCH_SIZE_DEFAULT);
+    }
+
+    /**
+     * 
+     * @return int The minimum sleep time used when mining redo/archive logs
+     */
+    public int getLogMiningSleepTimeMin() {
+        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_MIN);
+    }
+
+    /**
+     * 
+     * @return int The maximum sleep time used when mining redo/archive logs
+     */
+    public int getLogMiningSleepTimeMax() {
+        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_MAX);
+    }
+
+    /**
+     * 
+     * @return int The default sleep time used when mining redo/archive logs
+     */
+    public int getLogMiningSleepTimeDefault() {
+        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_DEFAULT);
+    }
+
+    /**
+     * 
+     * @return int The increment in sleep time when doing auto-tuning while mining redo/archive logs
+     */
+    public int getLogMiningSleepTimeIncrement() {
+        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_INCREMENT);
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
@@ -44,7 +44,7 @@ public class LogMinerHelper {
     private static final String TOTAL = "TOTAL";
     private final static Logger LOGGER = LoggerFactory.getLogger(LogMinerHelper.class);
 
-    public final static String MAX_SCN_S = "1844674407370955161";
+    public final static String MAX_SCN_S = "18446744073709551615";
     public final static BigInteger MAX_SCN_BI = new BigInteger(MAX_SCN_S);
 
     public enum DATATYPE {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.oracle.logminer;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.CallableStatement;
 import java.sql.Connection;
@@ -44,6 +43,9 @@ public class LogMinerHelper {
     private final static String UNKNOWN = "unknown";
     private static final String TOTAL = "TOTAL";
     private final static Logger LOGGER = LoggerFactory.getLogger(LogMinerHelper.class);
+
+    public final static String MAX_SCN_S = "1844674407370955161";
+    public final static BigInteger MAX_SCN_BI = new BigInteger(MAX_SCN_S);
 
     public enum DATATYPE {
         LONG,
@@ -462,8 +464,8 @@ public class LogMinerHelper {
 
         removeLogFilesFromMining(connection);
 
-        Map<String, Long> onlineLogFilesForMining = getOnlineLogFilesForOffsetScn(connection, lastProcessedScn);
-        Map<String, Long> archivedLogFilesForMining = getArchivedLogFilesForOffsetScn(connection, lastProcessedScn, archiveLogRetention);
+        Map<String, BigInteger> onlineLogFilesForMining = getOnlineLogFilesForOffsetScn(connection, lastProcessedScn);
+        Map<String, BigInteger> archivedLogFilesForMining = getArchivedLogFilesForOffsetScn(connection, lastProcessedScn, archiveLogRetention);
 
         if (onlineLogFilesForMining.size() + archivedLogFilesForMining.size() == 0) {
             throw new IllegalStateException("None of log files contains offset SCN: " + lastProcessedScn + ", re-snapshot is required.");
@@ -524,18 +526,21 @@ public class LogMinerHelper {
      * @return size
      */
     private static int getRedoLogGroupSize(Connection connection) throws SQLException {
-        return getMap(connection, SqlUtils.allOnlineLogsQuery(), "-1").size();
+        return getMap(connection, SqlUtils.allOnlineLogsQuery(), MAX_SCN_S).size();
     }
 
     /**
      * This method returns all online log files, starting from one which contains offset SCN and ending with one containing largest SCN
      * 18446744073709551615 on Ora 19c is the max value of the nextScn in the current redo todo replace all Long with BigInteger for SCN
      */
-    public static Map<String, Long> getOnlineLogFilesForOffsetScn(Connection connection, Long offsetScn) throws SQLException {
-        Map<String, String> redoLogFiles = getMap(connection, SqlUtils.allOnlineLogsQuery(), "-1");
+    public static Map<String, BigInteger> getOnlineLogFilesForOffsetScn(Connection connection, Long offsetScn) throws SQLException {
+
+        // TODO: Make offset a BigInteger and refactor upstream
+        BigInteger offsetScnBi = BigInteger.valueOf(offsetScn);
+        Map<String, String> redoLogFiles = getMap(connection, SqlUtils.allOnlineLogsQuery(), MAX_SCN_S);
         return redoLogFiles.entrySet().stream()
-                .filter(entry -> new BigInteger(entry.getValue()).longValue() > offsetScn || new BigInteger(entry.getValue()).longValue() == -1).collect(Collectors
-                        .toMap(Map.Entry::getKey, e -> new BigInteger(e.getValue()).longValue() == -1 ? Long.MAX_VALUE : new BigInteger(e.getValue()).longValue()));
+                .filter(entry -> new BigInteger(entry.getValue()).compareTo(offsetScnBi) >= 0 || new BigInteger(entry.getValue()).equals(MAX_SCN_BI)).collect(Collectors
+                        .toMap(Map.Entry::getKey, e -> new BigInteger(e.getValue()).equals(MAX_SCN_BI) ? MAX_SCN_BI : new BigInteger(e.getValue())));
     }
 
     /**
@@ -546,10 +551,10 @@ public class LogMinerHelper {
      * @return                Map of archived files
      * @throws SQLException   if something happens
      */
-    public static Map<String, Long> getArchivedLogFilesForOffsetScn(Connection connection, Long offsetScn, Duration archiveLogRetention) throws SQLException {
-        Map<String, String> redoLogFiles = getMap(connection, SqlUtils.archiveLogsQuery(offsetScn, archiveLogRetention), "-1");
+    public static Map<String, BigInteger> getArchivedLogFilesForOffsetScn(Connection connection, Long offsetScn, Duration archiveLogRetention) throws SQLException {
+        Map<String, String> redoLogFiles = getMap(connection, SqlUtils.archiveLogsQuery(offsetScn, archiveLogRetention), MAX_SCN_S);
         return redoLogFiles.entrySet().stream().collect(
-                Collectors.toMap(Map.Entry::getKey, e -> new BigDecimal(e.getValue()).longValue() == -1 ? Long.MAX_VALUE : new BigDecimal(e.getValue()).longValue()));
+                Collectors.toMap(Map.Entry::getKey, e -> new BigInteger(e.getValue()).equals(MAX_SCN_BI) ? MAX_SCN_BI : new BigInteger(e.getValue())));
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
@@ -164,7 +164,7 @@ public class LogMinerHelper {
      * @return next SCN to mine up to
      * @throws SQLException if anything unexpected happens
      */
-    static long getEndScn(Connection connection, long startScn, LogMinerMetrics metrics) throws SQLException {
+    static long getEndScn(Connection connection, long startScn, LogMinerMetrics metrics, int defaultBatchSize) throws SQLException {
         long currentScn = getCurrentScn(connection);
         metrics.setCurrentScn(currentScn);
 
@@ -172,11 +172,11 @@ public class LogMinerHelper {
 
         // adjust batch size
         boolean topMiningScnInFarFuture = false;
-        if ((topScnToMine - currentScn) > LogMinerMetrics.DEFAULT_BATCH_SIZE) {
+        if ((topScnToMine - currentScn) > defaultBatchSize) {
             metrics.changeBatchSize(false);
             topMiningScnInFarFuture = true;
         }
-        if ((currentScn - topScnToMine) > LogMinerMetrics.DEFAULT_BATCH_SIZE) {
+        if ((currentScn - topScnToMine) > defaultBatchSize) {
             metrics.changeBatchSize(true);
         }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperIT.java
@@ -8,6 +8,7 @@ package io.debezium.connector.oracle;
 import static org.fest.assertions.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -112,7 +113,7 @@ public class LogMinerHelperIT extends AbstractConnectorTest {
         // case 2: oldest scn = oldest in not cleared archive
         List<BigDecimal> oneDayArchivedNextScn = getOneDayArchivedLogNextScn(conn);
         long oldestArchivedScn = getOldestArchivedScn(oneDayArchivedNextScn);
-        Map<String, Long> archivedLogsForMining = LogMinerHelper.getArchivedLogFilesForOffsetScn(conn, oldestArchivedScn, Duration.ofHours(0L));
+        Map<String, BigInteger> archivedLogsForMining = LogMinerHelper.getArchivedLogFilesForOffsetScn(conn, oldestArchivedScn, Duration.ofHours(0L));
         assertThat(archivedLogsForMining.size() == (oneDayArchivedNextScn.size() - 1)).isTrue();
 
         archivedRedoFiles = LogMinerHelper.getMap(conn, SqlUtils.archiveLogsQuery(oldestArchivedScn - 1, Duration.ofHours(0L)), "-1");
@@ -126,8 +127,8 @@ public class LogMinerHelperIT extends AbstractConnectorTest {
         LogMinerHelper.setRedoLogFilesForMining(conn, oldestArchivedScn, Duration.ofHours(0L));
 
         // eliminate duplications
-        Map<String, Long> onlineLogFilesForMining = LogMinerHelper.getOnlineLogFilesForOffsetScn(conn, oldestArchivedScn);
-        Map<String, Long> archivedLogFilesForMining = LogMinerHelper.getArchivedLogFilesForOffsetScn(conn, oldestArchivedScn, Duration.ofHours(0L));
+        Map<String, BigInteger> onlineLogFilesForMining = LogMinerHelper.getOnlineLogFilesForOffsetScn(conn, oldestArchivedScn);
+        Map<String, BigInteger> archivedLogFilesForMining = LogMinerHelper.getArchivedLogFilesForOffsetScn(conn, oldestArchivedScn, Duration.ofHours(0L));
         List<String> archivedLogFiles = archivedLogFilesForMining.entrySet().stream()
                 .filter(e -> !onlineLogFilesForMining.values().contains(e.getValue())).map(Map.Entry::getKey).collect(Collectors.toList());
         int archivedLogFilesCount = archivedLogFiles.size();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.debezium.connector.oracle.logminer.LogMinerHelper;
+
+public class LogMinerHelperTest {
+
+    private Connection connection = Mockito.mock(Connection.class);
+    private int current;
+    private String[][] mockRows;
+
+    @Before
+    public void beforeEach() throws Exception {
+
+        current = 0;
+        mockRows = new String[][]{};
+
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        PreparedStatement pstmt = Mockito.mock(PreparedStatement.class);
+        Mockito.when(connection.prepareStatement(anyString())).thenReturn(pstmt);
+        Mockito.when(pstmt.executeQuery()).thenReturn(rs);
+        Mockito.when(rs.next()).thenAnswer(it -> ++current > mockRows.length ? false : true);
+        Mockito.when(rs.getString(anyInt())).thenAnswer(it -> {
+            return mockRows[current - 1][(Integer) it.getArguments()[0] - 1];
+        });
+    }
+
+    @Test
+    public void logsWithRegularScns() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" }
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getOnlineLogFilesForOffsetScn(connection, 10L);
+        assertEquals(onlineLogs.size(), 2);
+        assertEquals(onlineLogs.get("logfile1"), BigInteger.valueOf(103400L));
+        assertEquals(onlineLogs.get("logfile2"), BigInteger.valueOf(103700L));
+    }
+
+    @Test
+    public void excludeLogsBeforeOffsetScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", "500", "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getOnlineLogFilesForOffsetScn(connection, 600L);
+        assertEquals(onlineLogs.size(), 2);
+        assertNull(onlineLogs.get("logfile3"));
+    }
+
+    @Test
+    public void nullsHandledAsMaxScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", null, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getOnlineLogFilesForOffsetScn(connection, 600L);
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), LogMinerHelper.MAX_SCN_BI);
+    }
+
+    @Test
+    public void canHandleMaxScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", LogMinerHelper.MAX_SCN_S, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getOnlineLogFilesForOffsetScn(connection, 600L);
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), LogMinerHelper.MAX_SCN_BI);
+    }
+
+    @Test
+    public void logsWithLongerScnAreSupported() throws Exception {
+
+        // Proves that a SCN larger than what long data type supports, is still handled appropriately
+        String scnLonger = "9295429630892703743";
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", scnLonger, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getOnlineLogFilesForOffsetScn(connection, 600L);
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), new BigInteger(scnLonger));
+    }
+
+    @Test
+    public void archiveLogsWithRegularScns() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" }
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getArchivedLogFilesForOffsetScn(connection, 500L, Duration.ofDays(60));
+        assertEquals(onlineLogs.size(), 2);
+        assertEquals(onlineLogs.get("logfile1"), BigInteger.valueOf(103400L));
+        assertEquals(onlineLogs.get("logfile2"), BigInteger.valueOf(103700L));
+    }
+
+    // Following are the same set of tests used for online logs but on archived logs
+    @Test
+    @Ignore // TODO: Is this test not passing a bug?
+    public void archiveExcludeLogsBeforeOffsetScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", "500", "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getArchivedLogFilesForOffsetScn(connection, 600L, Duration.ofDays(60));
+        assertEquals(onlineLogs.size(), 2);
+        assertNull(onlineLogs.get("logfile3"));
+    }
+
+    @Test
+    public void archiveNullsHandledAsMaxScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", null, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getArchivedLogFilesForOffsetScn(connection, 500L, Duration.ofDays(60));
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), LogMinerHelper.MAX_SCN_BI);
+    }
+
+    @Test
+    public void archiveCanHandleMaxScn() throws Exception {
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", LogMinerHelper.MAX_SCN_S, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getArchivedLogFilesForOffsetScn(connection, 500L, Duration.ofDays(60));
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), LogMinerHelper.MAX_SCN_BI);
+    }
+
+    @Test
+    public void archiveLogsWithLongerScnAreSupported() throws Exception {
+
+        // Proves that a SCN larger than what long data type supports, is still handled appropriately
+        String scnLonger = "9295429630892703743";
+
+        mockRows = new String[][]{
+                new String[]{ "logfile1", "103400", "11" },
+                new String[]{ "logfile2", "103700", "12" },
+                new String[]{ "logfile3", scnLonger, "13" },
+        };
+
+        Map<String, BigInteger> onlineLogs = LogMinerHelper.getArchivedLogFilesForOffsetScn(connection, 500L, Duration.ofDays(60));
+        assertEquals(onlineLogs.size(), 3);
+        assertEquals(onlineLogs.get("logfile3"), new BigInteger(scnLonger));
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.oracle;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -104,5 +105,51 @@ public class OracleConnectorConfigTest {
                         .with(OracleConnectorConfig.USER, "debezium")
                         .build());
         assertFalse(connectorConfig.getConfig().validateAndRecord(connectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+    @Test
+    public void validBatchDefaults() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                        .build());
+
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_DEFAULT), OracleConnectorConfig.DEFAULT_BATCH_SIZE);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_MAX), OracleConnectorConfig.MAX_BATCH_SIZE);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_MIN), OracleConnectorConfig.MIN_BATCH_SIZE);
+
+        assertEquals(connectorConfig.getLogMiningBatchSizeDefault(), OracleConnectorConfig.DEFAULT_BATCH_SIZE);
+        assertEquals(connectorConfig.getLogMiningBatchSizeMax(), OracleConnectorConfig.MAX_BATCH_SIZE);
+        assertEquals(connectorConfig.getLogMiningBatchSizeMin(), OracleConnectorConfig.MIN_BATCH_SIZE);
+    }
+
+    @Test
+    public void validSleepDefaults() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                        .build());
+
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_DEFAULT), OracleConnectorConfig.DEFAULT_SLEEP_TIME);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MAX), OracleConnectorConfig.MAX_SLEEP_TIME);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MIN), OracleConnectorConfig.MIN_SLEEP_TIME);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_INCREMENT), OracleConnectorConfig.SLEEP_TIME_INCREMENT);
+
+        assertEquals(connectorConfig.getLogMiningSleepTimeDefault(), OracleConnectorConfig.DEFAULT_SLEEP_TIME);
+        assertEquals(connectorConfig.getLogMiningSleepTimeMax(), OracleConnectorConfig.MAX_SLEEP_TIME);
+        assertEquals(connectorConfig.getLogMiningSleepTimeMin(), OracleConnectorConfig.MIN_SLEEP_TIME);
+        assertEquals(connectorConfig.getLogMiningSleepTimeIncrement(), OracleConnectorConfig.SLEEP_TIME_INCREMENT);
+    }
+
+    @Test
+    public void validViewFetchSizeDefaults() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                        .build());
+
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_VIEW_FETCH_SIZE), OracleConnectorConfig.DEFAULT_VIEW_FETCH_SIZE);
+
+        assertEquals(connectorConfig.getLogMiningViewFetchSize(), OracleConnectorConfig.DEFAULT_VIEW_FETCH_SIZE);
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerMetricsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerMetricsTest.java
@@ -19,7 +19,9 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.mockito.Mockito;
 
+import io.debezium.config.Configuration;
 import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;
@@ -28,6 +30,7 @@ import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;
 public class LogMinerMetricsTest {
 
     private LogMinerMetrics metrics;
+    private OracleConnectorConfig connectorConfig;
 
     @Rule
     public TestRule skipRule = new SkipTestDependingOnAdapterNameRule();
@@ -37,7 +40,8 @@ public class LogMinerMetricsTest {
         CdcSourceTaskContext taskContext = mock(CdcSourceTaskContext.class);
         Mockito.when(taskContext.getConnectorName()).thenReturn("connector name");
         Mockito.when(taskContext.getConnectorType()).thenReturn("connector type");
-        metrics = new LogMinerMetrics(taskContext);
+        connectorConfig = new OracleConnectorConfig(Configuration.create().build());
+        metrics = new LogMinerMetrics(taskContext, connectorConfig);
     }
 
     @Test
@@ -50,9 +54,9 @@ public class LogMinerMetricsTest {
         assertThat(metrics.getCurrentScn()).isEqualTo(1000L);
 
         metrics.setBatchSize(10);
-        assertThat(metrics.getBatchSize() == LogMinerMetrics.DEFAULT_BATCH_SIZE).isTrue();
+        assertThat(metrics.getBatchSize() == connectorConfig.getLogMiningBatchSizeDefault()).isTrue();
         metrics.setBatchSize(1_000_000);
-        assertThat(metrics.getBatchSize()).isEqualTo(LogMinerMetrics.DEFAULT_BATCH_SIZE);
+        assertThat(metrics.getBatchSize()).isEqualTo(connectorConfig.getLogMiningBatchSizeDefault());
         metrics.setBatchSize(6000);
         assertThat(metrics.getBatchSize()).isEqualTo(6_000);
 


### PR DESCRIPTION
This change makes some of the log mining constant properties available to be tuned through the connector configuration. I've added support for the SCN batch window properties as well as for sleep time and fetch size. 

This change alleviates slightly the issue reported on DBZ-2982 in the sense that it provides some capability to increase the batch window and sleep time so in case of encountering a SCN jump it will be possible to soften the effects by using larger batch sizes and smaller sleep intervals. Of course this might not target some of the use cases and ideally this PR should be complemented by additional improvements like either a better algorithm or a different approach to handle those SCN jumps better.