### PR TITLE
DBZ-2982 Allow to customize log mining properties

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -50,6 +50,17 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     public static final String DATABASE_CONFIG_PREFIX = "database.";
 
     protected static final int DEFAULT_PORT = 1528;
+    
+    protected static final int DEFAULT_VIEW_FETCH_SIZE = 10_000;
+
+    protected final static int DEFAULT_BATCH_SIZE = 20_000;
+    protected final static int MIN_BATCH_SIZE = 1_000;
+    protected final static int MAX_BATCH_SIZE = 100_000;
+
+    protected final static int MAX_SLEEP_TIME = 3_000;
+    protected final static int DEFAULT_SLEEP_TIME = 1_000;
+    protected final static int MIN_SLEEP_TIME = 0;
+    protected final static int SLEEP_TIME_INCREMENT = 200;
 
     public static final Field HOSTNAME = Field.create(DATABASE_CONFIG_PREFIX + JdbcConfiguration.HOSTNAME)
             .withDisplayName("Hostname")
@@ -222,6 +233,75 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withDefault(0)
             .withDescription("The number of hours in the past from SYSDATE to mine archive logs.  Using 0 mines all available archive logs");
 
+    public static final Field LOG_MINING_BATCH_SIZE_MIN = Field.create("log.mining.batch.size.min")
+            .withDisplayName("Minimum batch size for reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(MIN_BATCH_SIZE)
+            .withDescription(
+                    "The minimum SCN interval size that this connector will try to read from redo/archive logs. Active batch size will be also increased/decreased by this amount for tuning connector throughput when needed.");
+
+    public static final Field LOG_MINING_BATCH_SIZE_DEFAULT = Field.create("log.mining.batch.size.default")
+            .withDisplayName("Default batch size for reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(DEFAULT_BATCH_SIZE)
+            .withDescription("The starting SCN interval size that the connector will use for reading data from redo/archive logs.");
+
+    public static final Field LOG_MINING_BATCH_SIZE_MAX = Field.create("log.mining.batch.size.max")
+            .withDisplayName("Maximum batch size for reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(MAX_BATCH_SIZE)
+            .withDescription("The maximum SCN interval size that this connector will use when reading from redo/archive logs.");
+
+    public static final Field LOG_MINING_VIEW_FETCH_SIZE = Field.create("log.mining.view.fetch.size")
+            .withDisplayName("Number of content records that will be fetched.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(DEFAULT_VIEW_FETCH_SIZE)
+            .withDescription("The number of content records that will be fetched from the log miner content view.");
+
+    public static final Field LOG_MINING_SLEEP_TIME_MIN = Field.create("log.mining.sleep.time.min")
+            .withDisplayName("Minimum sleep time in milliseconds when reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(MIN_SLEEP_TIME)
+            .withDescription(
+                    "The minimum amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
+
+    public static final Field LOG_MINING_SLEEP_TIME_DEFAULT = Field.create("log.mining.sleep.time.default")
+            .withDisplayName("Default sleep time in milliseconds when reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(DEFAULT_SLEEP_TIME)
+            .withDescription(
+                    "The amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
+
+    public static final Field LOG_MINING_SLEEP_TIME_MAX = Field.create("log.mining.sleep.time.max")
+            .withDisplayName("Maximum sleep time in milliseconds when reading redo/archive logs.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(MAX_SLEEP_TIME)
+            .withDescription(
+                    "The maximum amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
+
+    public static final Field LOG_MINING_SLEEP_TIME_INCREMENT = Field.create("log.mining.sleep.time.increment")
+            .withDisplayName("The increment in sleep time in milliseconds used to tune auto-sleep behavior.")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(SLEEP_TIME_INCREMENT)
+            .withDescription(
+                    "The maximum amount of time that the connector will use to tune the optimal sleep time when reading data from logminer. Value is in milliseconds.");
+
     /**
      * The set of {@link Field}s defined as part of this configuration.
      */
@@ -262,7 +342,14 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             RAC_NODES,
             CommonConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE,
             URL,
-            LOG_MINING_ARCHIVE_LOG_HOURS);
+            LOG_MINING_ARCHIVE_LOG_HOURS,
+            LOG_MINING_BATCH_SIZE_DEFAULT,
+            LOG_MINING_BATCH_SIZE_MIN,
+            LOG_MINING_BATCH_SIZE_MAX,
+            LOG_MINING_SLEEP_TIME_DEFAULT,
+            LOG_MINING_SLEEP_TIME_MIN,
+            LOG_MINING_SLEEP_TIME_MAX,
+            LOG_MINING_SLEEP_TIME_INCREMENT);
 
     private final String databaseName;
     private final String pdbName;
@@ -335,7 +422,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         Field.group(config, "Connector", CommonConnectorConfig.POLL_INTERVAL_MS, CommonConnectorConfig.MAX_BATCH_SIZE,
                 CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.SNAPSHOT_DELAY_MS, CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
                 SNAPSHOT_ENHANCEMENT_TOKEN, LOG_MINING_HISTORY_RECORDER_CLASS, LOG_MINING_HISTORY_RETENTION, RAC_SYSTEM, RAC_NODES,
-                LOG_MINING_ARCHIVE_LOG_HOURS);
+                LOG_MINING_ARCHIVE_LOG_HOURS, LOG_MINING_BATCH_SIZE_DEFAULT, LOG_MINING_BATCH_SIZE_MIN, LOG_MINING_BATCH_SIZE_MAX,
+                LOG_MINING_SLEEP_TIME_DEFAULT, LOG_MINING_SLEEP_TIME_MIN, LOG_MINING_SLEEP_TIME_MAX, LOG_MINING_SLEEP_TIME_INCREMENT);
 
         return config;
     }
@@ -713,6 +801,70 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
      */
     public Duration getLogMiningArchiveLogRetention() {
         return Duration.ofHours(getConfig().getLong(LOG_MINING_ARCHIVE_LOG_HOURS));
+    }
+
+    /**
+     * 
+     * @return int The minimum SCN interval used when mining redo/archive logs
+     */
+    public int getLogMiningBatchSizeMin() {
+        return getConfig().getInteger(LOG_MINING_BATCH_SIZE_MIN);
+    }
+
+    /**
+     * 
+     * @return int Number of actual records that will be fetched from the log mining contents view
+     */
+    public int getLogMiningViewFetchSize() {
+        return getConfig().getInteger(LOG_MINING_VIEW_FETCH_SIZE);
+    }
+
+    /**
+     * 
+     * @return int The maximum SCN interval used when mining redo/archive logs
+     */
+    public int getLogMiningBatchSizeMax() {
+        return getConfig().getInteger(LOG_MINING_BATCH_SIZE_MAX);
+    }
+
+    /**
+     * 
+     * @return int The default SCN interval used when mining redo/archive logs
+     */
+    public int getLogMiningBatchSizeDefault() {
+        return getConfig().getInteger(LOG_MINING_BATCH_SIZE_DEFAULT);
+    }
+
+    /**
+     * 
+     * @return int The minimum sleep time used when mining redo/archive logs
+     */
+    public int getLogMiningSleepTimeMin() {
+        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_MIN);
+    }
+
+    /**
+     * 
+     * @return int The maximum sleep time used when mining redo/archive logs
+     */
+    public int getLogMiningSleepTimeMax() {
+        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_MAX);
+    }
+
+    /**
+     * 
+     * @return int The default sleep time used when mining redo/archive logs
+     */
+    public int getLogMiningSleepTimeDefault() {
+        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_DEFAULT);
+    }
+
+    /**
+     * 
+     * @return int The increment in sleep time when doing auto-tuning while mining redo/archive logs
+     */
+    public int getLogMiningSleepTimeIncrement() {
+        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_INCREMENT);
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -57,10 +57,10 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     protected final static int MIN_BATCH_SIZE = 1_000;
     protected final static int MAX_BATCH_SIZE = 100_000;
 
-    protected final static int MAX_SLEEP_TIME = 3_000;
-    protected final static int DEFAULT_SLEEP_TIME = 1_000;
-    protected final static int MIN_SLEEP_TIME = 0;
-    protected final static int SLEEP_TIME_INCREMENT = 200;
+    protected final static int MAX_SLEEP_TIME_MS = 3_000;
+    protected final static int DEFAULT_SLEEP_TIME_MS = 1_000;
+    protected final static int MIN_SLEEP_TIME_MS = 0;
+    protected final static int SLEEP_TIME_INCREMENT_MS = 200;
 
     public static final Field HOSTNAME = Field.create(DATABASE_CONFIG_PREFIX + JdbcConfiguration.HOSTNAME)
             .withDisplayName("Hostname")
@@ -266,39 +266,39 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withDefault(DEFAULT_VIEW_FETCH_SIZE)
             .withDescription("The number of content records that will be fetched from the log miner content view.");
 
-    public static final Field LOG_MINING_SLEEP_TIME_MIN = Field.create("log.mining.sleep.time.min")
+    public static final Field LOG_MINING_SLEEP_TIME_MIN_MS = Field.create("log.mining.sleep.time.min.ms")
             .withDisplayName("Minimum sleep time in milliseconds when reading redo/archive logs.")
             .withType(Type.LONG)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
-            .withDefault(MIN_SLEEP_TIME)
+            .withDefault(MIN_SLEEP_TIME_MS)
             .withDescription(
                     "The minimum amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
 
-    public static final Field LOG_MINING_SLEEP_TIME_DEFAULT = Field.create("log.mining.sleep.time.default")
+    public static final Field LOG_MINING_SLEEP_TIME_DEFAULT_MS = Field.create("log.mining.sleep.time.default.ms")
             .withDisplayName("Default sleep time in milliseconds when reading redo/archive logs.")
             .withType(Type.LONG)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
-            .withDefault(DEFAULT_SLEEP_TIME)
+            .withDefault(DEFAULT_SLEEP_TIME_MS)
             .withDescription(
                     "The amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
 
-    public static final Field LOG_MINING_SLEEP_TIME_MAX = Field.create("log.mining.sleep.time.max")
+    public static final Field LOG_MINING_SLEEP_TIME_MAX_MS = Field.create("log.mining.sleep.time.max.ms")
             .withDisplayName("Maximum sleep time in milliseconds when reading redo/archive logs.")
             .withType(Type.LONG)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
-            .withDefault(MAX_SLEEP_TIME)
+            .withDefault(MAX_SLEEP_TIME_MS)
             .withDescription(
                     "The maximum amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.");
 
-    public static final Field LOG_MINING_SLEEP_TIME_INCREMENT = Field.create("log.mining.sleep.time.increment")
+    public static final Field LOG_MINING_SLEEP_TIME_INCREMENT_MS = Field.create("log.mining.sleep.time.increment.ms")
             .withDisplayName("The increment in sleep time in milliseconds used to tune auto-sleep behavior.")
             .withType(Type.LONG)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
-            .withDefault(SLEEP_TIME_INCREMENT)
+            .withDefault(SLEEP_TIME_INCREMENT_MS)
             .withDescription(
                     "The maximum amount of time that the connector will use to tune the optimal sleep time when reading data from logminer. Value is in milliseconds.");
 
@@ -346,10 +346,10 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             LOG_MINING_BATCH_SIZE_DEFAULT,
             LOG_MINING_BATCH_SIZE_MIN,
             LOG_MINING_BATCH_SIZE_MAX,
-            LOG_MINING_SLEEP_TIME_DEFAULT,
-            LOG_MINING_SLEEP_TIME_MIN,
-            LOG_MINING_SLEEP_TIME_MAX,
-            LOG_MINING_SLEEP_TIME_INCREMENT);
+            LOG_MINING_SLEEP_TIME_DEFAULT_MS,
+            LOG_MINING_SLEEP_TIME_MIN_MS,
+            LOG_MINING_SLEEP_TIME_MAX_MS,
+            LOG_MINING_SLEEP_TIME_INCREMENT_MS);
 
     private final String databaseName;
     private final String pdbName;
@@ -423,7 +423,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                 CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.SNAPSHOT_DELAY_MS, CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
                 SNAPSHOT_ENHANCEMENT_TOKEN, LOG_MINING_HISTORY_RECORDER_CLASS, LOG_MINING_HISTORY_RETENTION, RAC_SYSTEM, RAC_NODES,
                 LOG_MINING_ARCHIVE_LOG_HOURS, LOG_MINING_BATCH_SIZE_DEFAULT, LOG_MINING_BATCH_SIZE_MIN, LOG_MINING_BATCH_SIZE_MAX,
-                LOG_MINING_SLEEP_TIME_DEFAULT, LOG_MINING_SLEEP_TIME_MIN, LOG_MINING_SLEEP_TIME_MAX, LOG_MINING_SLEEP_TIME_INCREMENT);
+                LOG_MINING_SLEEP_TIME_DEFAULT_MS, LOG_MINING_SLEEP_TIME_MIN_MS, LOG_MINING_SLEEP_TIME_MAX_MS, LOG_MINING_SLEEP_TIME_INCREMENT_MS);
 
         return config;
     }
@@ -839,32 +839,32 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
      * 
      * @return int The minimum sleep time used when mining redo/archive logs
      */
-    public int getLogMiningSleepTimeMin() {
-        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_MIN);
+    public Duration getLogMiningSleepTimeMin() {
+        return Duration.ofMillis(getConfig().getInteger(LOG_MINING_SLEEP_TIME_MIN_MS));
     }
 
     /**
      * 
      * @return int The maximum sleep time used when mining redo/archive logs
      */
-    public int getLogMiningSleepTimeMax() {
-        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_MAX);
+    public Duration getLogMiningSleepTimeMax() {
+        return Duration.ofMillis(getConfig().getInteger(LOG_MINING_SLEEP_TIME_MAX_MS));
     }
 
     /**
      * 
      * @return int The default sleep time used when mining redo/archive logs
      */
-    public int getLogMiningSleepTimeDefault() {
-        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_DEFAULT);
+    public Duration getLogMiningSleepTimeDefault() {
+        return Duration.ofMillis(getConfig().getInteger(LOG_MINING_SLEEP_TIME_DEFAULT_MS));
     }
 
     /**
      * 
      * @return int The increment in sleep time when doing auto-tuning while mining redo/archive logs
      */
-    public int getLogMiningSleepTimeIncrement() {
-        return getConfig().getInteger(LOG_MINING_SLEEP_TIME_INCREMENT);
+    public Duration getLogMiningSleepTimeIncrement() {
+        return Duration.ofMillis(getConfig().getInteger(LOG_MINING_SLEEP_TIME_INCREMENT_MS));
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
@@ -167,7 +167,7 @@ public class LogMinerHelper {
      * @return next SCN to mine up to
      * @throws SQLException if anything unexpected happens
      */
-    static long getEndScn(Connection connection, long startScn, LogMinerMetrics metrics) throws SQLException {
+    static long getEndScn(Connection connection, long startScn, LogMinerMetrics metrics, int defaultBatchSize) throws SQLException {
         long currentScn = getCurrentScn(connection);
         metrics.setCurrentScn(currentScn);
 
@@ -175,11 +175,11 @@ public class LogMinerHelper {
 
         // adjust batch size
         boolean topMiningScnInFarFuture = false;
-        if ((topScnToMine - currentScn) > LogMinerMetrics.DEFAULT_BATCH_SIZE) {
+        if ((topScnToMine - currentScn) > defaultBatchSize) {
             metrics.changeBatchSize(false);
             topMiningScnInFarFuture = true;
         }
-        if ((currentScn - topScnToMine) > LogMinerMetrics.DEFAULT_BATCH_SIZE) {
+        if ((currentScn - topScnToMine) > defaultBatchSize) {
             metrics.changeBatchSize(true);
         }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
@@ -277,19 +277,29 @@ public class LogMinerMetrics extends Metrics implements LogMinerMetricsMXBean {
     public void changeSleepingTime(boolean increment) {
         int sleepTime = millisecondToSleepBetweenMiningQuery.get();
         if (increment && sleepTime < sleepTimeMax) {
-            millisecondToSleepBetweenMiningQuery.getAndAdd(sleepTimeIncrement);
+            sleepTime = millisecondToSleepBetweenMiningQuery.addAndGet(sleepTimeIncrement);
         }
         else if (sleepTime > sleepTimeMin) {
-            millisecondToSleepBetweenMiningQuery.getAndAdd(-sleepTimeIncrement);
+            sleepTime = millisecondToSleepBetweenMiningQuery.addAndGet(-sleepTimeIncrement);
         }
+
+        LOGGER.debug("Updating sleep time window. Sleep time {}. Min sleep time {}. Max sleep time {}.", sleepTime, sleepTimeMin, sleepTimeMax);
     }
 
     public void changeBatchSize(boolean increment) {
-        if (increment && batchSize.get() < batchSizeMax) {
-            batchSize.getAndAdd(batchSizeMin);
+        
+        int currentBatchSize = batchSize.get();
+        if (increment && currentBatchSize < batchSizeMax) {
+            currentBatchSize = batchSize.addAndGet(batchSizeMin);
         }
-        else if (batchSize.get() > batchSizeMin) {
-            batchSize.getAndAdd(-batchSizeMin);
+        else if (currentBatchSize > batchSizeMin) {
+            currentBatchSize = batchSize.addAndGet(-batchSizeMin);
+        }
+
+        if (currentBatchSize == batchSizeMax) {
+            LOGGER.info("LogMiner is now using the maximum batch size {}. This could be indicative of large SCN gaps", currentBatchSize);
+        } else {
+            LOGGER.debug("Updating batch size window. Batch size {}. Min batch size {}. Max batch size {}.", currentBatchSize, batchSizeMin, batchSizeMax);
         }
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
@@ -48,7 +48,7 @@ public class LogMinerMetrics extends Metrics implements LogMinerMetricsMXBean {
     private final AtomicInteger switchCounter = new AtomicInteger();
 
     private final AtomicInteger batchSize = new AtomicInteger();
-    private final AtomicInteger millisecondToSleepBetweenMiningQuery = new AtomicInteger();
+    private final AtomicLong millisecondToSleepBetweenMiningQuery = new AtomicLong();
 
     private final AtomicBoolean recordMiningHistory = new AtomicBoolean();
     private final AtomicInteger hoursToKeepTransaction = new AtomicInteger();
@@ -59,12 +59,12 @@ public class LogMinerMetrics extends Metrics implements LogMinerMetricsMXBean {
     private final int batchSizeMax;
     private final int batchSizeDefault;
 
-    //constants for sleeping algorithm
-    private final int sleepTimeMin;
-    private final int sleepTimeMax;
-    private final int sleepTimeDefault;
-    private final int sleepTimeIncrement;
-    
+    // constants for sleeping algorithm
+    private final long sleepTimeMin;
+    private final long sleepTimeMax;
+    private final long sleepTimeDefault;
+    private final long sleepTimeIncrement;
+
     LogMinerMetrics(CdcSourceTaskContext taskContext, OracleConnectorConfig connectorConfig) {
         super(taskContext, "log-miner");
 
@@ -77,10 +77,10 @@ public class LogMinerMetrics extends Metrics implements LogMinerMetricsMXBean {
         batchSizeMin = connectorConfig.getLogMiningBatchSizeMin();
         batchSizeMax = connectorConfig.getLogMiningBatchSizeMax();
 
-        sleepTimeDefault = connectorConfig.getLogMiningSleepTimeDefault();
-        sleepTimeMin = connectorConfig.getLogMiningSleepTimeMin();
-        sleepTimeMax = connectorConfig.getLogMiningSleepTimeMax();
-        sleepTimeIncrement = connectorConfig.getLogMiningSleepTimeIncrement();
+        sleepTimeDefault = connectorConfig.getLogMiningSleepTimeDefault().toMillis();
+        sleepTimeMin = connectorConfig.getLogMiningSleepTimeMin().toMillis();
+        sleepTimeMax = connectorConfig.getLogMiningSleepTimeMax().toMillis();
+        sleepTimeIncrement = connectorConfig.getLogMiningSleepTimeIncrement().toMillis();
 
         reset();
         LOGGER.info("Logminer metrics initialized {}", this);
@@ -235,7 +235,7 @@ public class LogMinerMetrics extends Metrics implements LogMinerMetricsMXBean {
 
     @Override
     public Integer getMillisecondToSleepBetweenMiningQuery() {
-        return millisecondToSleepBetweenMiningQuery.get();
+        return millisecondToSleepBetweenMiningQuery.intValue();
     }
 
     @Override
@@ -275,7 +275,7 @@ public class LogMinerMetrics extends Metrics implements LogMinerMetricsMXBean {
 
     @Override
     public void changeSleepingTime(boolean increment) {
-        int sleepTime = millisecondToSleepBetweenMiningQuery.get();
+        long sleepTime = millisecondToSleepBetweenMiningQuery.get();
         if (increment && sleepTime < sleepTimeMax) {
             sleepTime = millisecondToSleepBetweenMiningQuery.addAndGet(sleepTimeIncrement);
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
@@ -103,7 +103,7 @@ public class LogMinerMetrics extends Metrics implements LogMinerMetricsMXBean {
         totalBatchProcessingDuration.set(Duration.ZERO);
         maxBatchProcessingThroughput.set(0);
         lastBatchProcessingDuration.set(Duration.ZERO);
-        networkConnectionProblemsCounter.set(0);       
+        networkConnectionProblemsCounter.set(0);
     }
 
     // setters

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -158,7 +158,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
 
                         Stopwatch stopwatch = Stopwatch.reusable();
                         while (context.isRunning()) {
-                            endScn = getEndScn(connection, startScn, logMinerMetrics);
+                            endScn = getEndScn(connection, startScn, logMinerMetrics, connectorConfig.getLogMiningBatchSizeDefault());
                             flushLogWriter(connection, jdbcConfiguration, isRac, racHosts);
 
                             pauseBetweenMiningSessions();
@@ -240,7 +240,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
     }
 
     private void registerLogMinerMetrics() {
-        logMinerMetrics = new LogMinerMetrics(taskContext);
+        logMinerMetrics = new LogMinerMetrics(taskContext, connectorConfig);
         logMinerMetrics.register(LOGGER);
         if (connectorConfig.isLogMiningHistoryRecorded()) {
             logMinerMetrics.setRecordMiningHistory(true);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -130,15 +130,15 @@ public class OracleConnectorConfigTest {
                 Configuration.create()
                         .build());
 
-        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_DEFAULT), OracleConnectorConfig.DEFAULT_SLEEP_TIME);
-        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MAX), OracleConnectorConfig.MAX_SLEEP_TIME);
-        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MIN), OracleConnectorConfig.MIN_SLEEP_TIME);
-        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_INCREMENT), OracleConnectorConfig.SLEEP_TIME_INCREMENT);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_DEFAULT_MS), OracleConnectorConfig.DEFAULT_SLEEP_TIME_MS);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MAX_MS), OracleConnectorConfig.MAX_SLEEP_TIME_MS);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MIN_MS), OracleConnectorConfig.MIN_SLEEP_TIME_MS);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_INCREMENT_MS), OracleConnectorConfig.SLEEP_TIME_INCREMENT_MS);
 
-        assertEquals(connectorConfig.getLogMiningSleepTimeDefault(), OracleConnectorConfig.DEFAULT_SLEEP_TIME);
-        assertEquals(connectorConfig.getLogMiningSleepTimeMax(), OracleConnectorConfig.MAX_SLEEP_TIME);
-        assertEquals(connectorConfig.getLogMiningSleepTimeMin(), OracleConnectorConfig.MIN_SLEEP_TIME);
-        assertEquals(connectorConfig.getLogMiningSleepTimeIncrement(), OracleConnectorConfig.SLEEP_TIME_INCREMENT);
+        assertEquals(connectorConfig.getLogMiningSleepTimeDefault().toMillis(), OracleConnectorConfig.DEFAULT_SLEEP_TIME_MS);
+        assertEquals(connectorConfig.getLogMiningSleepTimeMax().toMillis(), OracleConnectorConfig.MAX_SLEEP_TIME_MS);
+        assertEquals(connectorConfig.getLogMiningSleepTimeMin().toMillis(), OracleConnectorConfig.MIN_SLEEP_TIME_MS);
+        assertEquals(connectorConfig.getLogMiningSleepTimeIncrement().toMillis(), OracleConnectorConfig.SLEEP_TIME_INCREMENT_MS);
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.oracle;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -104,5 +105,51 @@ public class OracleConnectorConfigTest {
                         .with(OracleConnectorConfig.USER, "debezium")
                         .build());
         assertFalse(connectorConfig.getConfig().validateAndRecord(connectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+    @Test
+    public void validBatchDefaults() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                        .build());
+
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_DEFAULT), OracleConnectorConfig.DEFAULT_BATCH_SIZE);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_MAX), OracleConnectorConfig.MAX_BATCH_SIZE);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_BATCH_SIZE_MIN), OracleConnectorConfig.MIN_BATCH_SIZE);
+
+        assertEquals(connectorConfig.getLogMiningBatchSizeDefault(), OracleConnectorConfig.DEFAULT_BATCH_SIZE);
+        assertEquals(connectorConfig.getLogMiningBatchSizeMax(), OracleConnectorConfig.MAX_BATCH_SIZE);
+        assertEquals(connectorConfig.getLogMiningBatchSizeMin(), OracleConnectorConfig.MIN_BATCH_SIZE);
+    }
+
+    @Test
+    public void validSleepDefaults() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                        .build());
+
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_DEFAULT), OracleConnectorConfig.DEFAULT_SLEEP_TIME);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MAX), OracleConnectorConfig.MAX_SLEEP_TIME);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_MIN), OracleConnectorConfig.MIN_SLEEP_TIME);
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_SLEEP_TIME_INCREMENT), OracleConnectorConfig.SLEEP_TIME_INCREMENT);
+
+        assertEquals(connectorConfig.getLogMiningSleepTimeDefault(), OracleConnectorConfig.DEFAULT_SLEEP_TIME);
+        assertEquals(connectorConfig.getLogMiningSleepTimeMax(), OracleConnectorConfig.MAX_SLEEP_TIME);
+        assertEquals(connectorConfig.getLogMiningSleepTimeMin(), OracleConnectorConfig.MIN_SLEEP_TIME);
+        assertEquals(connectorConfig.getLogMiningSleepTimeIncrement(), OracleConnectorConfig.SLEEP_TIME_INCREMENT);
+    }
+
+    @Test
+    public void validViewFetchSizeDefaults() throws Exception {
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create()
+                        .build());
+
+        assertEquals(connectorConfig.getConfig().getInteger(OracleConnectorConfig.LOG_MINING_VIEW_FETCH_SIZE), OracleConnectorConfig.DEFAULT_VIEW_FETCH_SIZE);
+
+        assertEquals(connectorConfig.getLogMiningViewFetchSize(), OracleConnectorConfig.DEFAULT_VIEW_FETCH_SIZE);
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -46,6 +46,7 @@ import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.heartbeat.Heartbeat;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.util.Testing;
 
 /**
@@ -1316,7 +1317,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "debezium.deadlock_test")
                     .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
                     .with(OracleConnectorConfig.MAX_QUEUE_SIZE, 2)
-                    .with(OracleConnectorConfig.MAX_BATCH_SIZE, 1)
+                    .with(RelationalDatabaseConnectorConfig.MAX_BATCH_SIZE, 1)
                     .build();
 
             start(OracleConnector.class, config);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerMetricsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerMetricsTest.java
@@ -19,7 +19,9 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.mockito.Mockito;
 
+import io.debezium.config.Configuration;
 import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;
@@ -28,6 +30,7 @@ import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;
 public class LogMinerMetricsTest {
 
     private LogMinerMetrics metrics;
+    private OracleConnectorConfig connectorConfig;
 
     @Rule
     public TestRule skipRule = new SkipTestDependingOnAdapterNameRule();
@@ -37,7 +40,8 @@ public class LogMinerMetricsTest {
         CdcSourceTaskContext taskContext = mock(CdcSourceTaskContext.class);
         Mockito.when(taskContext.getConnectorName()).thenReturn("connector name");
         Mockito.when(taskContext.getConnectorType()).thenReturn("connector type");
-        metrics = new LogMinerMetrics(taskContext);
+        connectorConfig = new OracleConnectorConfig(Configuration.create().build());
+        metrics = new LogMinerMetrics(taskContext, connectorConfig);
     }
 
     @Test
@@ -50,9 +54,9 @@ public class LogMinerMetricsTest {
         assertThat(metrics.getCurrentScn()).isEqualTo(1000L);
 
         metrics.setBatchSize(10);
-        assertThat(metrics.getBatchSize() == LogMinerMetrics.DEFAULT_BATCH_SIZE).isTrue();
+        assertThat(metrics.getBatchSize() == connectorConfig.getLogMiningBatchSizeDefault()).isTrue();
         metrics.setBatchSize(1_000_000);
-        assertThat(metrics.getBatchSize()).isEqualTo(LogMinerMetrics.DEFAULT_BATCH_SIZE);
+        assertThat(metrics.getBatchSize()).isEqualTo(connectorConfig.getLogMiningBatchSizeDefault());
         metrics.setBatchSize(6000);
         assertThat(metrics.getBatchSize()).isEqualTo(6_000);
 


### PR DESCRIPTION
This change makes some of the log mining constant properties available to be tuned through the connector configuration. I've added support for the SCN batch window properties as well as for sleep time and fetch size.

This change alleviates slightly the issue reported on DBZ-2982 in the sense that it provides some capability to increase the batch window and sleep time so in case of encountering a SCN jump it will be possible to soften the effects by using larger batch sizes and smaller sleep intervals. Of course this might not target some of the use cases and ideally this PR should be complemented by additional improvements like either a better algorithm or a different approach to handle those SCN jumps better.