### PR TITLE
DBZ-3090 Fix emitting transaction end event for LogMiner

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
@@ -120,7 +120,7 @@ class LogMinerQueryResultProcessor {
                 if (transactionalBuffer.isTransactionRegistered(txId)) {
                     historyRecorder.record(scn, tableName, segOwner, operationCode, changeTime, txId, 0, redoSql);
                 }
-                if (transactionalBuffer.commit(txId, scn, offsetContext, changeTime, context, logMessage)) {
+                if (transactionalBuffer.commit(txId, scn, offsetContext, changeTime, context, logMessage, dispatcher)) {
                     LOGGER.trace("COMMIT, {}", logMessage);
                     commitCounter++;
                 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
@@ -54,7 +54,7 @@ class LogMinerQueryResultProcessor {
     LogMinerQueryResultProcessor(ChangeEventSource.ChangeEventSourceContext context, LogMinerMetrics metrics,
                                  TransactionalBuffer transactionalBuffer, SimpleDmlParser dmlParser,
                                  OracleOffsetContext offsetContext, OracleDatabaseSchema schema,
-                                 EventDispatcher<TableId> dispatcher, TransactionalBufferMetrics transactionalBufferMetrics,
+                                 EventDispatcher<TableId> dispatcher,
                                  String catalogName, Clock clock, HistoryRecorder historyRecorder) {
         this.context = context;
         this.metrics = metrics;
@@ -63,7 +63,7 @@ class LogMinerQueryResultProcessor {
         this.offsetContext = offsetContext;
         this.schema = schema;
         this.dispatcher = dispatcher;
-        this.transactionalBufferMetrics = transactionalBufferMetrics;
+        this.transactionalBufferMetrics = transactionalBuffer.getMetrics();
         this.catalogName = catalogName;
         this.clock = clock;
         this.historyRecorder = historyRecorder;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetrics.java
@@ -35,7 +35,6 @@ public class TransactionalBufferMetrics extends Metrics implements Transactional
     private final AtomicLong committedDmlCounter = new AtomicLong();
     private final AtomicLong lastCommitDuration = new AtomicLong();
     private final AtomicLong maxCommitDuration = new AtomicLong();
-    private final AtomicInteger commitQueueCapacity = new AtomicInteger();
     private final AtomicReference<Duration> lagFromTheSource = new AtomicReference<>();
     private final AtomicReference<Duration> maxLagFromTheSource = new AtomicReference<>();
     private final AtomicReference<Duration> minLagFromTheSource = new AtomicReference<>();
@@ -235,15 +234,6 @@ public class TransactionalBufferMetrics extends Metrics implements Transactional
         return scnFreezeCounter.get();
     }
 
-    @Override
-    public int getCommitQueueCapacity() {
-        return commitQueueCapacity.get();
-    }
-
-    void setCommitQueueCapacity(int commitQueueCapacity) {
-        this.commitQueueCapacity.set(commitQueueCapacity);
-    }
-
     public Long getLastCommitDuration() {
         return lastCommitDuration.get();
     }
@@ -267,7 +257,6 @@ public class TransactionalBufferMetrics extends Metrics implements Transactional
         errorCounter.set(0);
         warningCounter.set(0);
         scnFreezeCounter.set(0);
-        commitQueueCapacity.set(0);
     }
 
     @Override
@@ -290,7 +279,6 @@ public class TransactionalBufferMetrics extends Metrics implements Transactional
                 ", errorCounter=" + errorCounter.get() +
                 ", warningCounter=" + warningCounter.get() +
                 ", scnFreezeCounter=" + scnFreezeCounter.get() +
-                ", commitQueueCapacity=" + commitQueueCapacity.get() +
                 '}';
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetricsMXBean.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetricsMXBean.java
@@ -104,13 +104,6 @@ public interface TransactionalBufferMetricsMXBean {
     Set<String> getRolledBackTransactionIds();
 
     /**
-     * Gets commit queue capacity. As the queue fills up, this reduces to zero
-     *
-     * @return the commit queue capacity
-     */
-    int getCommitQueueCapacity();
-
-    /**
      * Reset metrics
      */
     void reset();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/TransactionMetadataIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/TransactionMetadataIT.java
@@ -17,16 +17,14 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestRule;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnectorConfig.SnapshotMode;
-import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
-import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIs;
 import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
+import io.debezium.doc.FixFor;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.util.Collect;
 import io.debezium.util.Testing;
@@ -40,14 +38,12 @@ public class TransactionMetadataIT extends AbstractConnectorTest {
 
     private static OracleConnection connection;
 
-    @Rule
-    public TestRule skipRule = new SkipTestDependingOnAdapterNameRule();
-
     @BeforeClass
     public static void beforeClass() throws SQLException {
         connection = TestHelper.testConnection();
 
         TestHelper.dropTable(connection, "debezium.customer");
+        TestHelper.dropTable(connection, "debezium.orders");
 
         String ddl = "create table debezium.customer (" +
                 "  id numeric(9,0) not null, " +
@@ -60,6 +56,18 @@ public class TransactionMetadataIT extends AbstractConnectorTest {
         connection.execute(ddl);
         connection.execute("GRANT SELECT ON debezium.customer to  " + TestHelper.getConnectorUserName());
         connection.execute("ALTER TABLE debezium.customer ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS");
+
+        ddl = "create table debezium.orders (" +
+                " id number(6) not null primary key, " +
+                " order_date date not null, " +
+                " purchaser number(4) not null, " +
+                " quantity number(4) not null, " +
+                " product_id number(4) not null" +
+                ")";
+
+        connection.execute(ddl);
+        connection.execute("GRANT SELECT ON debezium.orders to  " + TestHelper.getConnectorUserName());
+        connection.execute("ALTER TABLE debezium.orders ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS");
     }
 
     @AfterClass
@@ -72,18 +80,19 @@ public class TransactionMetadataIT extends AbstractConnectorTest {
     @Before
     public void before() throws SQLException {
         connection.execute("delete from debezium.customer");
+        connection.execute("delete from debezium.orders");
         setConsumeTimeout(TestHelper.defaultMessageConsumerPollTimeout(), TimeUnit.SECONDS);
         initializeConnectorTestFramework();
         Testing.Files.delete(TestHelper.DB_HISTORY_PATH);
     }
 
     @Test
-    @SkipWhenAdapterNameIs(value = SkipWhenAdapterNameIs.AdapterName.LOGMINER, reason = "End transaction is not emitted")
     public void transactionMetadata() throws Exception {
         Configuration config = TestHelper.defaultConfig()
-                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER,DEBEZIUM\\.ORDERS")
                 .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
                 .with(OracleConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
+                .with(OracleConnectorConfig.LOG_MINING_STRATEGY, OracleConnectorConfig.LogMiningStrategy.ONLINE_CATALOG)
                 .build();
 
         start(OracleConnector.class, config);
@@ -91,25 +100,119 @@ public class TransactionMetadataIT extends AbstractConnectorTest {
 
         waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
-        // Testing.Print.enable();
-        connection.execute("INSERT INTO debezium.customer VALUES (1, 'Billie-Bob', 1234.56, TO_DATE('2018/02/22', 'yyyy-mm-dd'))");
+        connection.executeWithoutCommitting("INSERT INTO debezium.customer VALUES (1, 'Billie-Bob', 1234.56, TO_DATE('2018/02/22', 'yyyy-mm-dd'))");
+        connection.executeWithoutCommitting("INSERT INTO debezium.orders VALUES (1, '01-FEB-2021', 1001, 1, 102)");
         connection.execute("COMMIT");
 
-        // TX BEGIN, insert, TX END
-        final int expectedRecordCount = 1 + 1 + 1;
+        // TX BEGIN, insert x2, TX END
+        final int expectedRecordCount = 1 + 2 + 1;
         List<SourceRecord> records = consumeRecordsByTopic(expectedRecordCount).allRecordsInOrder();
         assertThat(records).hasSize(expectedRecordCount);
 
-        final String expectedTxId = assertBeginTransaction(records.get(0));
+        // TX Begin
+        SourceRecord record = records.get(0);
+        String expectedTxId = assertBeginTransaction(record);
 
-        // insert
-        VerifyRecord.isValidInsert(records.get(1), "ID", 1);
-        Struct after = (Struct) ((Struct) records.get(1).value()).get("after");
+        // Insert customer
+        record = records.get(1);
+        VerifyRecord.isValidInsert(record, "ID", 1);
+        Struct after = (Struct) ((Struct) record.value()).get(Envelope.FieldName.AFTER);
         assertThat(after.get("ID")).isEqualTo(1);
         assertThat(after.get("NAME")).isEqualTo("Billie-Bob");
         assertThat(after.get("SCORE")).isEqualTo(BigDecimal.valueOf(1234.56));
-        assertRecordTransactionMetadata(records.get(1), expectedTxId, 1, 1);
+        assertRecordTransactionMetadata(record, expectedTxId, 1, 1);
 
-        assertEndTransaction(records.get(2), expectedTxId, 1, Collect.hashMapOf("ORCLPDB1.DEBEZIUM.CUSTOMER", 1));
+        // Insert orders
+        record = records.get(2);
+        VerifyRecord.isValidInsert(record, "ID", 1);
+        after = (Struct) ((Struct) record.value()).get(Envelope.FieldName.AFTER);
+        assertThat(after.get("ID")).isEqualTo(1);
+        assertThat(after.get("ORDER_DATE")).isEqualTo(1612137600000L);
+        assertThat(after.get("PURCHASER")).isEqualTo((short) 1001);
+        assertThat(after.get("QUANTITY")).isEqualTo((short) 1);
+        assertThat(after.get("PRODUCT_ID")).isEqualTo((short) 102);
+        assertRecordTransactionMetadata(record, expectedTxId, 2, 1);
+
+        // TX End
+        record = records.get(3);
+        assertEndTransaction(record, expectedTxId, 2, Collect.hashMapOf("ORCLPDB1.DEBEZIUM.CUSTOMER", 1, "ORCLPDB1.DEBEZIUM.ORDERS", 1));
+    }
+
+    @Test
+    @FixFor("DBZ-3090")
+    public void transactionMetadataMultipleTransactions() throws Exception {
+        try (OracleConnection secondaryConn = TestHelper.testConnection()) {
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER,DEBEZIUM\\.ORDERS")
+                    .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                    .with(OracleConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
+                    .with(OracleConnectorConfig.LOG_MINING_STRATEGY, OracleConnectorConfig.LogMiningStrategy.ONLINE_CATALOG)
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            // Create multiple transaction commits, notice commit order
+            connection.executeWithoutCommitting("INSERT INTO debezium.customer VALUES (1, 'Billie-Bob', 1234.56, TO_DATE('2018/02/22', 'yyyy-mm-dd'))");
+            connection.executeWithoutCommitting("INSERT INTO debezium.orders VALUES (2, '01-FEB-2021', 1001, 2, 102)");
+            secondaryConn.executeWithoutCommitting("INSERT INTO debezium.orders VALUES (1, '01-FEB-2021', 1001, 1, 102)");
+            secondaryConn.execute("COMMIT");
+            connection.execute("COMMIT");
+
+            // 2 TX BEGIN, 3 insert, 2 TX END
+            final int expectedRecordCount = 2 + 3 + 2;
+            List<SourceRecord> records = consumeRecordsByTopic(expectedRecordCount).allRecordsInOrder();
+            assertThat(records).hasSize(expectedRecordCount);
+
+            // TX Begin
+            SourceRecord record = records.get(0);
+            String expectedTxId = assertBeginTransaction(record);
+
+            // Insert orders (secondaryConn commit)
+            record = records.get(1);
+            VerifyRecord.isValidInsert(record, "ID", 1);
+            Struct after = (Struct) ((Struct) record.value()).get(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("ORDER_DATE")).isEqualTo(1612137600000L);
+            assertThat(after.get("PURCHASER")).isEqualTo((short) 1001);
+            assertThat(after.get("QUANTITY")).isEqualTo((short) 1);
+            assertThat(after.get("PRODUCT_ID")).isEqualTo((short) 102);
+            assertRecordTransactionMetadata(record, expectedTxId, 1, 1);
+
+            // TX End
+            record = records.get(2);
+            assertEndTransaction(record, expectedTxId, 1, Collect.hashMapOf("ORCLPDB1.DEBEZIUM.ORDERS", 1));
+
+            // TX Begin
+            record = records.get(3);
+            expectedTxId = assertBeginTransaction(record);
+
+            // Insert customer (connection commit)
+            record = records.get(4);
+            VerifyRecord.isValidInsert(record, "ID", 1);
+            after = (Struct) ((Struct) record.value()).get(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("NAME")).isEqualTo("Billie-Bob");
+            assertThat(after.get("SCORE")).isEqualTo(BigDecimal.valueOf(1234.56));
+            assertRecordTransactionMetadata(record, expectedTxId, 1, 1);
+
+            // Insert orders (connection commit)
+            record = records.get(5);
+            VerifyRecord.isValidInsert(record, "ID", 2);
+            after = (Struct) ((Struct) record.value()).get(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(2);
+            assertThat(after.get("ORDER_DATE")).isEqualTo(1612137600000L);
+            assertThat(after.get("PURCHASER")).isEqualTo((short) 1001);
+            assertThat(after.get("QUANTITY")).isEqualTo((short) 2);
+            assertThat(after.get("PRODUCT_ID")).isEqualTo((short) 102);
+            assertRecordTransactionMetadata(record, expectedTxId, 2, 1);
+
+            // TX End
+            record = records.get(6);
+            assertEndTransaction(record, expectedTxId, 2, Collect.hashMapOf("ORCLPDB1.DEBEZIUM.CUSTOMER", 1, "ORCLPDB1.DEBEZIUM.ORDERS", 1));
+        }
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetricsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetricsTest.java
@@ -148,9 +148,5 @@ public class TransactionalBufferMetricsTest {
 
         metrics.setOffsetScn(10L);
         assertThat(metrics.getOldestScn() == 10).isTrue();
-
-        metrics.setCommitQueueCapacity(1000);
-        assertThat(metrics.getCommitQueueCapacity()).isEqualTo(1000);
-
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3090

The outstanding question mentioned in the associated issue is whether or not we believe we need to rework the commit handler logic used by the commit-thread executor.  For now, this PR simply addresses making sure that the transaction-end event is emitted when the transaction is committed.