### PR TITLE
DBZ-3009 Support multiple schemas with Oracle LogMiner

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -6,6 +6,8 @@
 package io.debezium.connector.oracle;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -119,7 +121,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
     public static final Field LOG_MINING_STRATEGY = Field.create("log.mining.strategy")
             .withDisplayName("Log Mining Strategy")
-            .withEnum(LogMiningStrategy.class, LogMiningStrategy.CATALOG_IN_REDO)
+            .withEnum(LogMiningStrategy.class, LogMiningStrategy.ONLINE_CATALOG)
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.HIGH)
             .withDescription("There are strategies: Online catalog with faster mining but no captured DDL. Another - with data dictionary loaded into REDO LOG files");
@@ -744,24 +746,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
         @Override
         public boolean isIncluded(TableId t) {
-            return !t.schema().toLowerCase().equals("appqossys") &&
-                    !t.schema().toLowerCase().equals("audsys") &&
-                    !t.schema().toLowerCase().equals("ctxsys") &&
-                    !t.schema().toLowerCase().equals("dvsys") &&
-                    !t.schema().toLowerCase().equals("dbsfwuser") &&
-                    !t.schema().toLowerCase().equals("dbsnmp") &&
-                    !t.schema().toLowerCase().equals("gsmadmin_internal") &&
-                    !t.schema().toLowerCase().equals("lbacsys") &&
-                    !t.schema().toLowerCase().equals("mdsys") &&
-                    !t.schema().toLowerCase().equals("ojvmsys") &&
-                    !t.schema().toLowerCase().equals("olapsys") &&
-                    !t.schema().toLowerCase().equals("orddata") &&
-                    !t.schema().toLowerCase().equals("ordsys") &&
-                    !t.schema().toLowerCase().equals("outln") &&
-                    !t.schema().toLowerCase().equals("sys") &&
-                    !t.schema().toLowerCase().equals("system") &&
-                    !t.schema().toLowerCase().equals("wmsys") &&
-                    !t.schema().toLowerCase().equals("xdb");
+            return !OracleConnectorConfig.getExcludedSchemaNames().contains(t.schema().toLowerCase());
         }
     }
 
@@ -930,6 +915,12 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     @Override
     public String getConnectorName() {
         return Module.name();
+    }
+
+    public static List<String> getExcludedSchemaNames() {
+        return Arrays.asList("appqossys", "audsys", "ctxsys", "dvsys", "dbsfwuser", "dbsnmp", "gsmadmin_internal",
+                "lbacsys", "mdsys", "ojvmsys", "olapsys", "orddata", "ordsys", "outln", "sys", "system",
+                "wmsys", "xdb");
     }
 
     public static int validateOutServerName(Configuration config, Field field, ValidationOutput problems) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -121,7 +121,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
     public static final Field LOG_MINING_STRATEGY = Field.create("log.mining.strategy")
             .withDisplayName("Log Mining Strategy")
-            .withEnum(LogMiningStrategy.class, LogMiningStrategy.ONLINE_CATALOG)
+            .withEnum(LogMiningStrategy.class, LogMiningStrategy.CATALOG_IN_REDO)
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.HIGH)
             .withDescription("There are strategies: Online catalog with faster mining but no captured DDL. Another - with data dictionary loaded into REDO LOG files");

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -74,13 +74,12 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
             jdbcConnection.setSessionToPdb(connectorConfig.getPdbName());
         }
 
-        return new OracleSnapshotContext(
-                connectorConfig.getPdbName() != null ? connectorConfig.getPdbName() : connectorConfig.getDatabaseName());
+        return new OracleSnapshotContext(connectorConfig.getCatalogName());
     }
 
     @Override
     protected Set<TableId> getAllTableIds(RelationalSnapshotContext ctx) throws Exception {
-        return jdbcConnection.getAllTableIds(ctx.catalogName, connectorConfig.getSchemaName(), false);
+        return jdbcConnection.getAllTableIds(ctx.catalogName, null, false);
         // this very slow approach(commented out), it took 30 minutes on an instance with 600 tables
         // return jdbcConnection.readTableNames(ctx.catalogName, null, null, new String[] {"TABLE"} );
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
@@ -176,9 +176,6 @@ class LogMinerQueryResultProcessor {
             // DML
             if (operationCode == RowMapper.INSERT || operationCode == RowMapper.DELETE || operationCode == RowMapper.UPDATE) {
                 final TableId tableId = RowMapper.getTableId(connectorConfig.getCatalogName(), resultSet);
-                if (!connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)) {
-                    continue;
-                }
 
                 LOGGER.trace("DML,  {}, sql {}", logMessage, redoSql);
                 dmlCounter++;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -64,7 +64,6 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
     private final Clock clock;
     private final OracleDatabaseSchema schema;
     private final OracleOffsetContext offsetContext;
-    private final String catalogName;
     private final boolean isRac;
     private final Set<String> racHosts = new HashSet<>();
     private final JdbcConfiguration jdbcConfiguration;
@@ -89,7 +88,6 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
         this.schema = schema;
         this.offsetContext = offsetContext;
         this.connectorConfig = connectorConfig;
-        this.catalogName = (connectorConfig.getPdbName() != null) ? connectorConfig.getPdbName() : connectorConfig.getDatabaseName();
         this.strategy = connectorConfig.getLogMiningStrategy();
         this.isContinuousMining = connectorConfig.isContinuousMining();
         this.errorHandler = errorHandler;
@@ -142,9 +140,9 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
 
                     final LogMinerQueryResultProcessor processor = new LogMinerQueryResultProcessor(context, jdbcConnection,
                             connectorConfig, logMinerMetrics, transactionalBuffer, offsetContext, schema, dispatcher,
-                            catalogName, clock, historyRecorder);
+                            clock, historyRecorder);
 
-                    final String query = SqlUtils.logMinerContentsQuery(connectorConfig.getSchemaName(), jdbcConnection.username(), schema);
+                    final String query = SqlUtils.logMinerContentsQuery(connectorConfig, jdbcConnection.username());
                     try (PreparedStatement miningView = jdbcConnection.connection().prepareStatement(query, ResultSet.TYPE_FORWARD_ONLY,
                             ResultSet.CONCUR_READ_ONLY, ResultSet.HOLD_CURSORS_OVER_COMMIT)) {
                         Set<String> currentRedoLogFiles = getCurrentRedoLogFiles(jdbcConnection, logMinerMetrics);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/RowMapper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/RowMapper.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.DebeziumException;
 import io.debezium.relational.TableId;
 import io.debezium.util.HexConverter;
 
@@ -191,8 +192,13 @@ public class RowMapper {
         LogMinerHelper.logError(metrics, "Cannot get {}. This entry from LogMiner will be lost due to the {}", s, e);
     }
 
-    public static TableId getTableId(String catalogName, ResultSet rs) throws SQLException {
-        return new TableId(catalogName, rs.getString(SEG_OWNER), rs.getString(TABLE_NAME));
+    public static TableId getTableId(String catalogName, ResultSet rs) {
+        try {
+            return new TableId(catalogName, rs.getString(SEG_OWNER), rs.getString(TABLE_NAME));
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Cannot resolve TableId from result set data", e);
+        }
     }
 
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
@@ -228,6 +228,19 @@ public class SqlUtils {
         query.append("AND SCN < ? ");
         query.append("AND TABLE_NAME != '").append(LOGMNR_FLUSH_TABLE).append("' ");
 
+        List<String> excludedSchemas = OracleConnectorConfig.getExcludedSchemaNames();
+        if (!excludedSchemas.isEmpty()) {
+            query.append("AND SEG_OWNER NOT IN (");
+            for (Iterator<String> i = excludedSchemas.iterator(); i.hasNext();) {
+                String excludedSchema = i.next();
+                query.append("'").append(excludedSchema.toUpperCase()).append("'");
+                if (i.hasNext()) {
+                    query.append(",");
+                }
+            }
+            query.append(") ");
+        }
+
         String schemaPredicate = buildSchemaPredicate(connectorConfig);
         if (!Strings.isNullOrEmpty(schemaPredicate)) {
             query.append("AND ").append(schemaPredicate).append(" ");

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
@@ -228,6 +228,8 @@ public class SqlUtils {
         query.append("AND SCN < ? ");
         query.append("AND TABLE_NAME != '").append(LOGMNR_FLUSH_TABLE).append("' ");
 
+        // There are some common schemas that we automatically ignore when building the filter predicates
+        // and we pull that same list of schemas in here and apply those exclusions in the generated SQL.
         List<String> excludedSchemas = OracleConnectorConfig.getExcludedSchemaNames();
         if (!excludedSchemas.isEmpty()) {
             query.append("AND SEG_OWNER NOT IN (");

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/DmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/DmlParser.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.oracle.logminer.parser;
 
 import io.debezium.connector.oracle.logminer.valueholder.LogMinerDmlEntry;
+import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 
 /**
@@ -19,9 +20,10 @@ public interface DmlParser {
      *
      * @param sql the sql statement
      * @param tables collection of known tables.
+     * @param tableId the table identifier
      * @param txId the current transaction id the sql is part of.
      * @return the parsed sql as a DML entry or {@code null} if the SQL couldn't be parsed.
      * @throws DmlParserException thrown if a parse exception is detected.
      */
-    LogMinerDmlEntry parse(String sql, Tables tables, String txId);
+    LogMinerDmlEntry parse(String sql, Tables tables, TableId tableId, String txId);
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
@@ -15,6 +15,7 @@ import io.debezium.connector.oracle.logminer.valueholder.LogMinerColumnValueImpl
 import io.debezium.connector.oracle.logminer.valueholder.LogMinerDmlEntry;
 import io.debezium.connector.oracle.logminer.valueholder.LogMinerDmlEntryImpl;
 import io.debezium.data.Envelope;
+import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 
 /**
@@ -70,7 +71,7 @@ public class LogMinerDmlParser implements DmlParser {
     private static final int WHERE_LENGTH = WHERE.length();
 
     @Override
-    public LogMinerDmlEntry parse(String sql, Tables tables, String txId) {
+    public LogMinerDmlEntry parse(String sql, Tables tables, TableId tableId, String txId) {
         if (sql != null && sql.length() > 0) {
             switch (sql.charAt(0)) {
                 case 'i':

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -48,7 +48,6 @@ public class OracleConnectorConfigTest {
                         .with(OracleConnectorConfig.SERVER_NAME, "myserver")
                         .with(OracleConnectorConfig.HOSTNAME, "MyHostname")
                         .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
-                        .with(OracleConnectorConfig.SCHEMA_NAME, "myschema")
                         .with(OracleConnectorConfig.USER, "debezium")
                         .build());
         assertTrue(connectorConfig.validateAndRecord(OracleConnectorConfig.ALL_FIELDS, LOGGER::error));
@@ -77,7 +76,6 @@ public class OracleConnectorConfigTest {
                         .with(OracleConnectorConfig.SERVER_NAME, "myserver")
                         .with(OracleConnectorConfig.URL, "MyHostname")
                         .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
-                        .with(OracleConnectorConfig.SCHEMA_NAME, "myschema")
                         .with(OracleConnectorConfig.USER, "debezium")
                         .build());
         assertTrue(connectorConfig.validateAndRecord(OracleConnectorConfig.ALL_FIELDS, LOGGER::error));
@@ -93,7 +91,6 @@ public class OracleConnectorConfigTest {
                         .with(OracleConnectorConfig.URL,
                                 "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=192.68.1.11)(PORT=1701))(ADDRESS=(PROTOCOL=TCP)(HOST=192.68.1.12)(PORT=1701))(ADDRESS=(PROTOCOL=TCP)(HOST=192.68.1.13)(PORT=1701))(LOAD_BALANCE = yes)(FAILOVER = on)(CONNECT_DATA =(SERVER = DEDICATED)(SERVICE_NAME = myserver.mydomain.com)(FAILOVER_MODE =(TYPE = SELECT)(METHOD = BASIC)(RETRIES = 3)(DELAY = 5))))")
                         .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
-                        .with(OracleConnectorConfig.SCHEMA_NAME, "myschema")
                         .with(OracleConnectorConfig.USER, "debezium")
                         .build());
         assertTrue(connectorConfig.validateAndRecord(OracleConnectorConfig.ALL_FIELDS, LOGGER::error));
@@ -107,7 +104,6 @@ public class OracleConnectorConfigTest {
                         .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
                         .with(OracleConnectorConfig.SERVER_NAME, "myserver")
                         .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
-                        .with(OracleConnectorConfig.SCHEMA_NAME, "myschema")
                         .with(OracleConnectorConfig.USER, "debezium")
                         .build());
         assertFalse(connectorConfig.validateAndRecord(OracleConnectorConfig.ALL_FIELDS, LOGGER::error));

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorFilterIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorFilterIT.java
@@ -394,7 +394,7 @@ public class OracleConnectorFilterIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.SCHEMA_EXCLUDE_LIST, "DEBEZIUM,SYS")
-                .with(option, "DEBEZIUM\\.TABLE2,DEBEZIUM\\.CUSTOMER.*")
+                .with(option, "DEBEZIUM\\.TABLE2,DEBEZIUM\\.CUSTOMER.*,DEBEZIUM2\\.NOPK")
                 .with(OracleConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
                 .build();
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -255,19 +255,6 @@ public class OracleConnectorIT extends AbstractConnectorTest {
         continueStreamingAfterSnapshot(config);
     }
 
-    @Test
-    @FixFor("DBZ-2607")
-    @SkipWhenAdapterNameIs(value = SkipWhenAdapterNameIs.AdapterName.LOGMINER, reason = "Creates a backward compatibility regression")
-    public void shouldNotRequireDatabaseSchemaConfiguration() throws Exception {
-        final Map<String, ?> configMap = TestHelper.defaultConfig()
-                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CUSTOMER")
-                .build()
-                .asMap();
-        configMap.remove(OracleConnectorConfig.SCHEMA_NAME.name());
-
-        continueStreamingAfterSnapshot(Configuration.from(configMap));
-    }
-
     private void continueStreamingAfterSnapshot(Configuration config) throws Exception {
         int expectedRecordCount = 0;
         connection.execute("INSERT INTO debezium.customer VALUES (1, 'Billie-Bob', 1234.56, TO_DATE('2018/02/22', 'yyyy-mm-dd'))");
@@ -658,7 +645,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
-    @SkipWhenAdapterNameIs(value = SkipWhenAdapterNameIs.AdapterName.LOGMINER, reason = "Seems to get caught in loop?")
+    @SkipWhenAdapterNameIs(value = SkipWhenAdapterNameIs.AdapterName.LOGMINER, reason = "LogMiner does not yet support DDL during streaming")
     public void shouldReadChangeStreamForTableCreatedWhileStreaming() throws Exception {
         TestHelper.dropTable(connection, "debezium.customer2");
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerDmlParserTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerDmlParserTest.java
@@ -42,7 +42,7 @@ public class LogMinerDmlParserTest {
                 "('1','Acme',TO_TIMESTAMP('2020-02-01 00:00:00.'),Unsupported Type," +
                 "TO_DATE('2020-02-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),Unsupported Type,NULL);";
 
-        LogMinerDmlEntry entry = fastDmlParser.parse(sql, null, null);
+        LogMinerDmlEntry entry = fastDmlParser.parse(sql, null, null, null);
         assertThat(entry.getCommandType()).isEqualTo(Operation.CREATE);
         assertThat(entry.getOldValues()).isEmpty();
         assertThat(entry.getNewValues()).hasSize(7);
@@ -72,7 +72,7 @@ public class LogMinerDmlParserTest {
                 "\"UT\" = Unsupported Type and \"DATE\" = TO_DATE('2020-02-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS') and " +
                 "\"UT2\" = Unsupported Type and \"C1\" = NULL;";
 
-        LogMinerDmlEntry entry = fastDmlParser.parse(sql, null, null);
+        LogMinerDmlEntry entry = fastDmlParser.parse(sql, null, null, null);
         assertThat(entry.getCommandType()).isEqualTo(Operation.UPDATE);
         assertThat(entry.getOldValues()).hasSize(7);
         assertThat(entry.getOldValues().get(0).getColumnName()).isEqualTo("ID");
@@ -112,7 +112,7 @@ public class LogMinerDmlParserTest {
                 "where \"ID\" = '1' and \"NAME\" = 'Acme' and \"TS\" = TO_TIMESTAMP('2020-02-01 00:00:00.') and " +
                 "\"UT\" = Unsupported Type and \"DATE\" = TO_DATE('2020-02-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS');";
 
-        LogMinerDmlEntry entry = fastDmlParser.parse(sql, null, null);
+        LogMinerDmlEntry entry = fastDmlParser.parse(sql, null, null, null);
         assertThat(entry.getCommandType()).isEqualTo(Operation.DELETE);
         assertThat(entry.getOldValues()).hasSize(5);
         assertThat(entry.getOldValues().get(0).getColumnName()).isEqualTo("ID");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/RowMapperTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/RowMapperTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.mockito.Mockito;
 
+import io.debezium.DebeziumException;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;
@@ -171,7 +172,7 @@ public class RowMapperTest {
             tableId = RowMapper.getTableId("catalog", rs);
             fail("RowMapper should not have returned a TableId");
         }
-        catch (SQLException e) {
+        catch (DebeziumException e) {
             assertThat(tableId).isNull();
         }
     }
@@ -191,7 +192,7 @@ public class RowMapperTest {
             tableId = RowMapper.getTableId("catalog", rs);
             fail("RowMapper should not have returned a TableId");
         }
-        catch (SQLException e) {
+        catch (DebeziumException e) {
             assertThat(tableId).isNull();
         }
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ValueHolderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ValueHolderTest.java
@@ -33,6 +33,7 @@ import io.debezium.connector.oracle.logminer.valueholder.LogMinerDmlEntry;
 import io.debezium.connector.oracle.logminer.valueholder.LogMinerDmlEntryImpl;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
+import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.util.IoUtil;
 
@@ -45,6 +46,7 @@ public class ValueHolderTest {
     private SimpleDmlParser sqlDmlParser;
     private Tables tables;
     private static final String FULL_TABLE_NAME = SCHEMA_NAME + "\".\"" + TABLE_NAME;
+    private static final TableId TABLE_ID = TableId.parse(CATALOG_NAME + "." + SCHEMA_NAME + "." + TABLE_NAME);
 
     @Rule
     public TestRule skipRule = new SkipTestDependingOnAdapterNameRule();
@@ -53,7 +55,7 @@ public class ValueHolderTest {
     public void setUp() {
         OracleValueConverters converters = new OracleValueConverters(new OracleConnectorConfig(TestHelper.defaultConfig().build()), null);
         ddlParser = new OracleDdlParser(true, CATALOG_NAME, SCHEMA_NAME);
-        sqlDmlParser = new SimpleDmlParser(CATALOG_NAME, SCHEMA_NAME, converters);
+        sqlDmlParser = new SimpleDmlParser(CATALOG_NAME, converters);
         tables = new Tables();
     }
 
@@ -81,7 +83,7 @@ public class ValueHolderTest {
         ddlParser.parse(createStatement, tables);
 
         String dml = "insert into \"" + FULL_TABLE_NAME + "\"  (\"column1\",\"column2\") values ('5','Text');";
-        LogMinerDmlEntry dmlEntryParsed = sqlDmlParser.parse(dml, tables, "1");
+        LogMinerDmlEntry dmlEntryParsed = sqlDmlParser.parse(dml, tables, TABLE_ID, "1");
 
         assertThat(dmlEntryParsed.equals(dmlEntryExpected)).isTrue();
         assertThat(dmlEntryExpected.getCommandType() == Envelope.Operation.CREATE).isTrue();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -97,7 +97,6 @@ public class TestHelper {
         return builder.with(OracleConnectorConfig.SERVER_NAME, SERVER_NAME)
                 .with(OracleConnectorConfig.PDB_NAME, "ORCLPDB1")
                 .with(OracleConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)
-                .with(OracleConnectorConfig.SCHEMA_NAME, SCHEMA_USER)
                 .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
                 .with(OracleConnectorConfig.INCLUDE_SCHEMA_CHANGES, false);
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3009

This PR removes the `database.schema` configuration option and now supports multiple schemas based on the include/exclude lists provided by the common connector configurations.