### PR TITLE
DBZ-3128 Revert fix for DBZ-2679.

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -128,12 +128,11 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     }
 
     private TableId getTableId(LCR lcr) {
-        final String sourceDatabaseName = lcr.getSourceDatabaseName().split("\\.")[0];
         if (!this.tablenameCaseInsensitive) {
-            return new TableId(sourceDatabaseName, lcr.getObjectOwner(), lcr.getObjectName());
+            return new TableId(lcr.getSourceDatabaseName(), lcr.getObjectOwner(), lcr.getObjectName());
         }
         else {
-            return new TableId(sourceDatabaseName.toLowerCase(), lcr.getObjectOwner(), lcr.getObjectName().toLowerCase());
+            return new TableId(lcr.getSourceDatabaseName().toLowerCase(), lcr.getObjectOwner(), lcr.getObjectName().toLowerCase());
         }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3128

It is valid for Oracle XStreams to emit LCR records with a source database name with a domain, e.g. `ORCLCDB.WORLD`.  This will happen when the database's `GLOBAL_NAME` is configured with the same like value.   